### PR TITLE
wip

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 # Edit this file to allow external files into the Docker build.
 **
 !*requirements*.txt
+!test-torch-vision-nms.py
 !**/*requirements*.txt
 !*environment*.yaml
 !**/*environment*.yaml

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,10 @@ ENV_FILE = .env
 build: check vs # Rebuild the image before creating a new container.
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 \
 	docker compose -p ${PROJECT} up	--build -d ${SERVICE}
+build-dbg: check vs
+	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 \
+	docker compose -p ${PROJECT} up	--build -d ${SERVICE}
+
 build-only: check # Build the image without creating a new container.
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 \
 	docker compose -p ${PROJECT} build ${SERVICE}

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -63,7 +63,8 @@ ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
 ENV PYTHONUNBUFFERED=1
 RUN echo "sdfskdjfgl"  && \
-sleep 5 && \
-echo "YYYYYYYsYY"  
+    sync && \
+    sleep 5 && \
+    echo "YYYYYYYsYY"  
 # && \
 # VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -20,6 +20,7 @@ ARG PYTHON_VERSION=3.11.13
 # install miniconda
 RUN mkdir -p /miniconda3 && \
     wget ${CONDA_URL} -O /miniconda3/miniconda.sh && \
+    chmod +x /miniconda3/miniconda.sh && \
     /miniconda3/miniconda.sh -b -u -p /miniconda3 && \
     rm /miniconda3/miniconda.sh
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -37,6 +37,13 @@ RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkg
     conda clean -fya && rm -rf /tmp/conda/miniconda.sh && \
     find /miniconda3 -type d -name '__pycache__' | xargs rm -rf
 
+
+    RUN echo "2sdfskdjfgl"  && \
+    sleep 5 && \
+    echo "2YYYYYYYsYYa"  &&\
+    sleep 5 && \
+    echo "2YYYYYYYsYYa" 
+
 # Create a new conda environment with the same Python version as the system Python.
 # Initialize conda
 RUN /miniconda3/bin/conda init bash && \
@@ -54,6 +61,11 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 
 # Make RUN commands use the new environment
 SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
+RUN echo "3sdfskdjfgl"  && \
+    sleep 5 && \
+    echo "3YYYYYYYsYYa"  &&\
+    sleep 5 && \
+    echo "3YYYYYYYsYYa" 
 
 WORKDIR /opt/pytorch
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -8,12 +8,6 @@ ARG CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_25.7.0-2-Linu
 ARG CONDA_MANAGER=conda
 WORKDIR /tmp/conda
 
-RUN echo "1sdfskdjfgl"  && \
-    sleep 5 && \
-    echo "1YYYYYYYsYYa"  &&\
-    sleep 5 && \
-    echo "1YYYYYYYsYYa" 
-
 # install git, wget, bzip2, and other dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
@@ -37,18 +31,10 @@ RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkg
     conda clean -fya && rm -rf /tmp/conda/miniconda.sh && \
     find /miniconda3 -type d -name '__pycache__' | xargs rm -rf
 
-
-    RUN echo "2sdfskdjfgl"  && \
-    sleep 5 && \
-    echo "2YYYYYYYsYYa"  &&\
-    sleep 5 && \
-    echo "2YYYYYYYsYYa" 
-
 # Create a new conda environment with the same Python version as the system Python.
 # Initialize conda
 RUN /miniconda3/bin/conda init bash && \
     /miniconda3/bin/conda create -n py311 python=3.11 -y
-
 
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
@@ -59,19 +45,6 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --single-branch --shallow-submodules --recurse-submodules \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
 
-# Make RUN commands use the new environment
-RUN echo "33333333sdfskdjfgl"  && \
-    sleep 5 && \
-    echo "3YYYYYYYsYYa"  &&\
-    sleep 5 && \
-    echo "3YYYYYYYsYYa" 
-
-SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
-RUN echo "sdfskdjfgl"  && \
-    sleep 5 && \
-    echo "34YYYYYYYsYYa"  &&\
-    sleep 5 && \
-    echo "34YYYYYYYsYYa" 
 
 WORKDIR /opt/pytorch
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -61,5 +61,8 @@ RUN cat pyproject.toml && pip install --group dev
 
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
-RUN python -c "print ('X')"  && \
-    VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
+RUN python -c "print ('XXXXXXX')"  
+
+
+# && \
+#     VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -63,8 +63,8 @@ ENV PYTHONUNBUFFERED=1
 RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
 # install the wheel and verify torch imports and runs a basic op
-
-RUN pip install --no-index --find-links=/tmp/dist torch && \
+# python -m pip install --no-build-isolation -v .
+RUN pip install -no-build-isolation -v --no-index --find-links=/tmp/dist torch && \
     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -63,6 +63,6 @@ ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
 RUN python -c "print ('XXXXXXX')"  && \
 sleep 10 && \
-echo "YYYYYYYYY" 
+echo "YYYYYYYsYY" 
 # && \
 # VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -32,6 +32,11 @@ RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkg
     conda clean -fya && rm -rf /tmp/conda/miniconda.sh && \
     find /miniconda3 -type d -name '__pycache__' | xargs rm -rf
 
+# Create a new conda environment with the same Python version as the system Python.
+# Initialize conda
+RUN /miniconda3/bin/conda init bash && \
+    /miniconda3/bin/conda create -n py311 python=3.11 -y
+
 
 RUN ls /miniconda3/envs && exit 1
 
@@ -44,7 +49,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
 
 # Make RUN commands use the new environment
-SHELL ["/miniconda3/bin/conda", "run", "-n", "py31113", "/bin/bash", "-c"]
+SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
 
 WORKDIR /opt/pytorch
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04 as wheel-builder
 
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -61,3 +61,9 @@ ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 ENV PYTHONUNBUFFERED=1
 
 RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
+
+# Copy the built wheel to
+
+
+FROM wheel-builder AS export
+COPY --from=wheel-builder /tmp/dist /dist/wheels

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,5 +1,4 @@
-FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04 
-# as wheel-builder
+FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04  as wheel-builder
 
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -96,5 +95,5 @@ RUN ls /tmp/dist && python -m pip install /tmp/dist/torchvision-0.23.0a0+824e8c8
     python /test-torch-vision-nms.py
 
 
-# FROM wheel-builder AS export
-# COPY --from=wheel-builder /tmp/dist /dist/wheels
+FROM wheel-builder AS export
+COPY --from=wheel-builder /tmp/dist /dist/wheels

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -33,7 +33,7 @@ RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkg
     find /miniconda3 -type d -name '__pycache__' | xargs rm -rf
 
 
-RUN ls /miniconda3/envs && exit 1
+RUN ls /miniconda3 && exit 1
 
 
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -61,6 +61,7 @@ RUN cat pyproject.toml && pip install --group dev
 
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
+ENV PYTHONUNBUFFERED=1
 RUN echo "sdfskdjfgl"  && \
 sleep 5 && \
 echo "YYYYYYYsYY"  

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -33,7 +33,7 @@ RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkg
     find /miniconda3 -type d -name '__pycache__' | xargs rm -rf
 
 
-RUN ls /miniconda3 && exit 1
+RUN ls /miniconda3/envs && exit 1
 
 
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -61,4 +61,4 @@ RUN cat pyproject.toml && pip install --group dev
 
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
-RUN  python setup.py bdist_wheel -d /tmp/dist
+RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -49,15 +49,15 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
 
 WORKDIR /opt/pytorch
-ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
-# ARG BUILD_LIBTORCH_WHL=1
 
 RUN git submodule sync && \
     git submodule update --init --recursive
 
 # Install PyTorch build dependencies via `conda`
-
 # Run this command from the PyTorch directory after cloning the source code using the “Get the PyTorch Source“ section above
-RUN pip install --group dev
-RUN  python -X faulthandler setup.py bdist_wheel -d /tmp/dist
+RUN cat pyproject.toml && pip install --group dev
 
+
+ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
+# ARG BUILD_LIBTORCH_WHL=1
+# RUN  python -X faulthandler setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -8,11 +8,11 @@ ARG CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_25.7.0-2-Linu
 ARG CONDA_MANAGER=conda
 WORKDIR /tmp/conda
 
-RUN echo "sdfskdjfgl"  && \
+RUN echo "1sdfskdjfgl"  && \
     sleep 5 && \
-    echo "YYYYYYYsYYa"  &&\
+    echo "1YYYYYYYsYYa"  &&\
     sleep 5 && \
-    echo "YYYYYYYsYYa" 
+    echo "1YYYYYYYsYYa" 
 
 # install git, wget, bzip2, and other dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -42,7 +42,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
 
 # Make RUN commands use the new environment
-SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
+SHELL ["/miniconda3/bin/conda", "run", "-n", "py31113", "/bin/bash", "-c"]
 
 WORKDIR /opt/pytorch
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -63,5 +63,6 @@ ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
 RUN python -c "print ('XXXXXXX')"  && \
 sleep 1 && \
-echo "YYYYYYYYY" && \
-VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
+echo "YYYYYYYYY" 
+# && \
+# VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -64,7 +64,7 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
 # install the wheel and verify torch imports and runs a basic op
 
-RUN pip install --no-index --find-links=/dist/wheels torch && \
+RUN pip install --no-index --find-links=/tmp/dist torch && \
     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -60,7 +60,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
 
 # Make RUN commands use the new environment
-RUN echo "3sdfskdjfgl"  && \
+RUN echo "33333333sdfskdjfgl"  && \
     sleep 5 && \
     echo "3YYYYYYYsYYa"  &&\
     sleep 5 && \

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -33,12 +33,16 @@ RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkg
     find /miniconda3 -type d -name '__pycache__' | xargs rm -rf
 
 
+
+
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.
 RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --single-branch --shallow-submodules --recurse-submodules \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
-        
+
+# Make RUN commands use the new environment
+SHELL ["/opt/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
 
 WORKDIR /opt/pytorch
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
@@ -46,6 +50,8 @@ ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 
 RUN git submodule sync && \
     git submodule update --init --recursive
+
+# Install PyTorch build dependencies via `conda`
 
 # Run this command from the PyTorch directory after cloning the source code using the “Get the PyTorch Source“ section above
 RUN pip install --group dev

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
 
-ARG PYTORCH_VERSION_TAG=2.8.0
+ARG PYTORCH_VERSION_TAG=v2.8.0
 ARG TORCH_URL=https://github.com/pytorch/pytorch.git
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -8,6 +8,12 @@ ARG CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_25.7.0-2-Linu
 ARG CONDA_MANAGER=conda
 WORKDIR /tmp/conda
 
+RUN echo "sdfskdjfgl"  && \
+    sleep 5 && \
+    echo "YYYYYYYsYYa"  &&\
+    sleep 5 && \
+    echo "YYYYYYYsYYa" 
+
 # install git, wget, bzip2, and other dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -9,6 +9,12 @@ ARG CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_25.7.0-2-Linu
 ARG CONDA_MANAGER=conda
 WORKDIR /tmp/conda
 
+# install git, wget, bzip2, and other dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    wget &&\
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ARG conda=/opt/conda/bin/${CONDA_MANAGER}
 ARG PYTHON_VERSION=3.11.13
 # install miniconda

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -63,11 +63,36 @@ ENV PYTHONUNBUFFERED=1
 
 RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
+
+# Next build torch vision wheel
+# https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md#development-installation
+
+# Start by installing the nightly build of PyTorch (or in our case the wheel we just built)
+RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl
+
+
+ENV FORCE_CUDA=1
+
+WORKDIR /
+ARG PYTORCH_VISION_URL=https://github.com/pytorch/vision.git
+ARG PYTORCH_VISION_VERSION_TAG=v0.23.0
+RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
+        --single-branch --shallow-submodules --recurse-submodules \
+        --branch ${PYTORCH_VISION_VERSION_TAG} ${PYTORCH_VISION_URL} /opt/pytorch_vision && \
+         cd /opt/pytorch_vision && \
+         python setup.py bdist_wheel -d /tmp/dist
+
+
 # install the wheel and verify torch imports and runs a basic op
 # python -m pip install --no-build-isolation -v .
-WORKDIR /
 # RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
 #     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
+
+# First, check what GLIBCXX versions you have
+# strings /miniconda3/lib/libstdc++.so.6 | grep GLIBCXX
+
+# # Update libstdc++ and gcc
+# conda install -c conda-forge libstdcxx-ng
 
 # FROM wheel-builder AS export
 # COPY --from=wheel-builder /tmp/dist /dist/wheels

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -47,6 +47,5 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 WORKDIR /opt/pytorch
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
-RUN  pyenv shell 3.11.13 && \
-    python -X faulthandler setup.py bdist_wheel -d /tmp/dist
+RUN  python -X faulthandler setup.py bdist_wheel -d /tmp/dist
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -26,7 +26,10 @@ RUN mkdir -p /miniconda3 && \
 
 # /miniconda3/bin/activate in all future RUN commands
 ENV PATH="/miniconda3/bin:$PATH"
-RUN conda install python=${PYTHON_VERSION} && \
+RUN 
+     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
+     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
+    conda install python=${PYTHON_VERSION} && \
     conda clean -fya && rm -rf /tmp/conda/miniconda.sh && \
     find /miniconda3 -type d -name '__pycache__' | xargs rm -rf
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -62,7 +62,7 @@ RUN cat pyproject.toml && pip install --group dev
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
 RUN python -c "print ('XXXXXXX')"  && \
-sleep 1 && \
+sleep 10 && \
 echo "YYYYYYYYY" 
 # && \
 # VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -61,4 +61,5 @@ RUN cat pyproject.toml && pip install --group dev
 
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
-RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
+RUN python -c "print ('X')"  && \
+    VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -60,7 +60,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
 
 # Make RUN commands use the new environment
-SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
+# SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
 RUN echo "3sdfskdjfgl"  && \
     sleep 5 && \
     echo "3YYYYYYYsYYa"  &&\

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
+# Install python 3.11.13 using pyenv
+RUN curl -fsSL https://pyenv.run | bash
+
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.
 RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install python 3.11.13 using pyenv
-RUN curl -fsSL https://pyenv.run | bash
+RUN curl -fsSL https://pyenv.run | bash &&\
+    pyenv install 3.11.13
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.
@@ -20,5 +21,6 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 WORKDIR /opt/pytorch
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
-RUN python -X faulthandler setup.py bdist_wheel -d /tmp/dist
+RUN  pyenv shell 3.11.13 && \
+    python -X faulthandler setup.py bdist_wheel -d /tmp/dist
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -9,5 +9,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
 
 WORKDIR /opt/pytorch
+ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
+# ARG BUILD_LIBTORCH_WHL=1
 RUN python -X faulthandler setup.py bdist_wheel -d /tmp/dist
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -11,9 +11,11 @@ WORKDIR /tmp/conda
 
 ARG conda=/opt/conda/bin/${CONDA_MANAGER}
 ARG PYTHON_VERSION=3.11.13
-RUN /bin/bash /tmp/conda/miniconda.sh -b -p /opt/conda && \
+RUN curl ${CONDA_URL} -o /tmp/conda/miniconda && \
+    /bin/bash /tmp/conda/miniconda -b -p /opt/conda && \
     printf "channels:\n  - conda-forge\n  - nodefaults\nssl_verify: false\n" > /opt/conda/.condarc && \
-    $conda install -y python=${PYTHON_VERSION} && $conda clean -fya && \
+    $conda install python=${PYTHON_VERSION} && \
+    $conda clean -fya && rm -rf /tmp/conda/miniconda && \
     find /opt/conda -type d -name '__pycache__' | xargs rm -rf
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -61,4 +61,4 @@ RUN cat pyproject.toml && pip install --group dev
 
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
-# RUN  python -X faulthandler setup.py bdist_wheel -d /tmp/dist
+RUN  python -X faulthandler setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,5 +1,4 @@
-FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04 
-#as wheel-builder
+FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04 as wheel-builder
 
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -91,11 +90,10 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 # RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
 #     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
-# First, check what GLIBCXX versions you have
-# strings /miniconda3/lib/libstdc++.so.6 | grep GLIBCXX
+COPY test-torch-vision-nms.py /
+RUN python -m pip install /tmp/dist/torch_vision-0.23.0-cp311-cp311-linux_aarch64.whl && \
+    python /test-torch-vision-nms.py
 
-# # Update libstdc++ and gcc
-# conda install -c conda-forge libstdcxx-ng
 
 # FROM wheel-builder AS export
 # COPY --from=wheel-builder /tmp/dist /dist/wheels

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -61,8 +61,7 @@ RUN cat pyproject.toml && pip install --group dev
 
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
-RUN python -c "print ('XXXXXXX')"  
-
-
-# && \
-#     VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
+RUN python -c "print ('XXXXXXX')"  && \
+sleep 1 && \
+echo "YYYYYYYYY" && \
+VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,7 +1,6 @@
 FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
 
-ARG PYTORCH_VERSION_TAG=v2.8.0
-ARG TORCH_URL=https://github.com/pytorch/pytorch.git
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
@@ -41,6 +40,8 @@ RUN /miniconda3/bin/conda init bash && \
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.
+ARG PYTORCH_VERSION_TAG=/v2.9.0-rc2
+ARG TORCH_URL=https://github.com/pytorch/pytorch.git
 RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --single-branch --shallow-submodules --recurse-submodules \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -37,5 +37,8 @@ ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 
 RUN git submodule sync && \
     git submodule update --init --recursive
+
+# Run this command from the PyTorch directory after cloning the source code using the “Get the PyTorch Source“ section above
+RUN pip install --group dev
 RUN  python -X faulthandler setup.py bdist_wheel -d /tmp/dist
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -4,25 +4,18 @@ ARG PYTORCH_VERSION_TAG=v2.8.0
 ARG TORCH_URL=https://github.com/pytorch/pytorch.git
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
-# Install git 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl \
-    && rm -rf /var/lib/apt/lists/*
 
+ARG CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_25.7.0-2-Linux-aarch64.sh
+ARG CONDA_MANAGER=conda
+WORKDIR /tmp/conda
 
-RUN apt-get update && apt-get install -y \
-    software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update \
-    && apt-get install -y \
-    python3.11 \
-    python3.11-venv \
-    python3.11-dev \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
-
-# Create symlinks
-RUN ln -s /usr/bin/python3.11 /usr/bin/python 
+ARG conda=/opt/conda/bin/${CONDA_MANAGER}
+ARG PYTHON_VERSION=3.11.13
+RUN --mount=type=bind,from=curl-conda,source=/tmp/conda,target=/tmp/conda \
+    /bin/bash /tmp/conda/miniconda.sh -b -p /opt/conda && \
+    printf "channels:\n  - conda-forge\n  - nodefaults\nssl_verify: false\n" > /opt/conda/.condarc && \
+    $conda install -y python=${PYTHON_VERSION} && $conda clean -fya && \
+    find /opt/conda -type d -name '__pycache__' | xargs rm -rf
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -61,4 +61,4 @@ RUN cat pyproject.toml && pip install --group dev
 
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
-RUN  python -X faulthandler setup.py bdist_wheel -d /tmp/dist
+RUN  python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -65,6 +65,6 @@ ENV PYTHONUNBUFFERED=1
 RUN echo "sdfskdjfgl"  && \
     sync && \
     sleep 5 && \
-    echo "YYYYYYYsYY"  
+    echo "YYYYYYYsYYa"  
 # && \
 # VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -64,7 +64,7 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
 # install the wheel and verify torch imports and runs a basic op
 # python -m pip install --no-build-isolation -v .
-RUN python -m pip install -e --no-build-isolation -v --no-index --find-links=/tmp/dist torch && \
+RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -92,7 +92,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 #     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 COPY ./test-torch-vision-nms.py /test-torch-vision-nms.py
-RUN python -m pip install /tmp/dist/torch_vision-0.23.0-cp311-cp311-linux_aarch64.whl && \
+RUN ls /tmp/dist && python -m pip install /tmp/dist/torch_vision-0.23.0-cp311-cp311-linux_aarch64.whl && \
     python /test-torch-vision-nms.py
 
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04 as wheel-builder
+FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04 
+# as wheel-builder
 
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -64,8 +64,8 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
 # install the wheel and verify torch imports and runs a basic op
 
-# RUN pip install --no-index --find-links=/dist/wheels torch && \
-#     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
+RUN pip install --no-index --find-links=/dist/wheels torch && \
+    python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export
 COPY --from=wheel-builder /tmp/dist /dist/wheels

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -91,7 +91,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 # RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
 #     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
-COPY test-torch-vision-nms.py /test-torch-vision-nms.py
+COPY ./test-torch-vision-nms.py /test-torch-vision-nms.py
 RUN python -m pip install /tmp/dist/torch_vision-0.23.0-cp311-cp311-linux_aarch64.whl && \
     python /test-torch-vision-nms.py
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -62,8 +62,10 @@ ENV PYTHONUNBUFFERED=1
 
 RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
-# Copy the built wheel to
+# install the wheel and verify torch imports and runs a basic op
 
+RUN pip install --no-index --find-links=/dist/wheels torch && \
+    python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export
 COPY --from=wheel-builder /tmp/dist /dist/wheels

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -40,7 +40,7 @@ RUN /miniconda3/bin/conda init bash && \
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.
-ARG PYTORCH_VERSION_TAG=/v2.9.0-rc2
+ARG PYTORCH_VERSION_TAG=v2.9.0-rc2
 ARG TORCH_URL=https://github.com/pytorch/pytorch.git
 RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --single-branch --shallow-submodules --recurse-submodules \

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -91,7 +91,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 # RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
 #     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
-COPY test-torch-vision-nms.py /
+COPY test-torch-vision-nms.py /test-torch-vision-nms.py
 RUN python -m pip install /tmp/dist/torch_vision-0.23.0-cp311-cp311-linux_aarch64.whl && \
     python /test-torch-vision-nms.py
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Create symlinks
-RUN ln -s /usr/bin/python3.11 /usr/bin/python \
+RUN ln -s /usr/bin/python3.11 /usr/bin/python 
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -67,8 +67,11 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 # Next build torch vision wheel
 # https://github.com/pytorch/vision/blob/main/CONTRIBUTING.md#development-installation
 
+#  conda install -c conda-forge libstdcxx-ng  is to resolve -- ImportError: /miniconda3/bin/../lib/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /miniconda3/lib/python3.11/site-packages/torch/lib/libtorch_python.so)
+
 # Start by installing the nightly build of PyTorch (or in our case the wheel we just built)
-RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl
+RUN conda install -c conda-forge libstdcxx-ng && \
+    python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl
 
 
 ENV FORCE_CUDA=1

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install python 3.11.13 using pyenv
-RUN curl -fsSL https://pyenv.run | bash &&\
-    pyenv install 3.11.13
+RUN curl -fsSL https://pyenv.run | bash
+RUN pyenv install 3.11.13
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,0 +1,13 @@
+FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
+
+ARG PYTORCH_VERSION_TAG=2.8.0
+ARG TORCH_URL=https://github.com/pytorch/pytorch.git
+# Minimize downloads by only cloning shallow branches and not the full `git` history.
+# Use at most 8 jobs for cloning the repository and its submodules.
+RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
+        --single-branch --shallow-submodules --recurse-submodules \
+        --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
+
+WORKDIR /opt/pytorch
+RUN python -X faulthandler setup.py bdist_wheel -d /tmp/dist
+

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -2,6 +2,12 @@ FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
 
 ARG PYTORCH_VERSION_TAG=v2.8.0
 ARG TORCH_URL=https://github.com/pytorch/pytorch.git
+
+# Install git 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.
 RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -91,7 +91,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 # RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
 #     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
-COPY test-torch-vision-nms.py /
+COPY ./test-torch-vision-nms.py /
 RUN python -m pip install /tmp/dist/torch_vision-0.23.0-cp311-cp311-linux_aarch64.whl && \
     python /test-torch-vision-nms.py
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -8,9 +8,34 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install python 3.11.13 using pyenv
-RUN curl -fsSL https://pyenv.run | bash
-RUN pyenv install 3.11.13
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    wget \
+    build-essential \
+    zlib1g-dev \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libssl-dev \
+    libreadline-dev \
+    libffi-dev \
+    libsqlite3-dev \
+    libbz2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download and compile Python 3.11.13
+RUN wget https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tgz \
+    && tar -xzf Python-3.11.13.tgz \
+    && cd Python-3.11.13 \
+    && ./configure --enable-optimizations \
+    && make -j$(nproc) \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-3.11.13.tgz Python-3.11.13
+
+# Create symlinks
+RUN ln -s /usr/local/bin/python3.11 /usr/local/bin/python \
+    && ln -s /usr/local/bin/pip3.11 /usr/local/bin/pip
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -34,5 +34,8 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 WORKDIR /opt/pytorch
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
+
+RUN git submodule sync && \
+    git submodule update --init --recursive
 RUN  python -X faulthandler setup.py bdist_wheel -d /tmp/dist
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04 as wheel-builder
+FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04 
+#as wheel-builder
 
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -5,7 +5,7 @@ ARG TORCH_URL=https://github.com/pytorch/pytorch.git
 
 # Install git 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
+    git curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install python 3.11.13 using pyenv
@@ -17,6 +17,7 @@ RUN curl -fsSL https://pyenv.run | bash &&\
 RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --single-branch --shallow-submodules --recurse-submodules \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
+        
 
 WORKDIR /opt/pytorch
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -11,12 +11,17 @@ WORKDIR /tmp/conda
 
 ARG conda=/opt/conda/bin/${CONDA_MANAGER}
 ARG PYTHON_VERSION=3.11.13
-RUN curl ${CONDA_URL} -o /tmp/conda/miniconda && \
-    /bin/bash /tmp/conda/miniconda -b -p /opt/conda && \
-    printf "channels:\n  - conda-forge\n  - nodefaults\nssl_verify: false\n" > /opt/conda/.condarc && \
-    $conda install python=${PYTHON_VERSION} && \
-    $conda clean -fya && rm -rf /tmp/conda/miniconda && \
-    find /opt/conda -type d -name '__pycache__' | xargs rm -rf
+# install miniconda
+RUN wget ${CONDA_URL} -O /miniconda3/miniconda.sh && \
+    /miniconda3/miniconda.sh -b -u -p /miniconda3 && \
+    rm /miniconda3/miniconda.sh
+
+# /miniconda3/bin/activate in all future RUN commands
+ENV PATH="/miniconda3/bin:$PATH"
+RUN conda install python=${PYTHON_VERSION} && \
+    conda clean -fya && rm -rf /tmp/conda/miniconda.sh && \
+    find /miniconda3 -type d -name '__pycache__' | xargs rm -rf
+
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04  as wheel-builder
+FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04  AS wheel-builder
 
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -96,4 +96,4 @@ RUN ls /tmp/dist && python -m pip install /tmp/dist/torchvision-0.23.0a0+824e8c8
 
 
 FROM wheel-builder AS export
-COPY --from=wheel-builder /tmp/dist /dist/wheels
+COPY --from=wheel-builder /tmp/dist /dist/wheels2

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -64,7 +64,7 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
 # install the wheel and verify torch imports and runs a basic op
 # python -m pip install --no-build-isolation -v .
-RUN python -m pip install --no-build-isolation -v --no-index --find-links=/tmp/dist torch && \
+RUN python -m pip install -e --no-build-isolation -v --no-index --find-links=/tmp/dist torch && \
     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -64,7 +64,7 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
 # install the wheel and verify torch imports and runs a basic op
 # python -m pip install --no-build-isolation -v .
-RUN pip install --no-build-isolation -v --no-index --find-links=/tmp/dist torch && \
+RUN python -m pip install --no-build-isolation -v --no-index --find-links=/tmp/dist torch && \
     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -65,8 +65,8 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 # install the wheel and verify torch imports and runs a basic op
 # python -m pip install --no-build-isolation -v .
 WORKDIR /
-RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
-    python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
+# RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
+#     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export
 COPY --from=wheel-builder /tmp/dist /dist/wheels

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -8,34 +8,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies
 RUN apt-get update && apt-get install -y \
-    wget \
-    build-essential \
-    zlib1g-dev \
-    libncurses5-dev \
-    libgdbm-dev \
-    libnss3-dev \
-    libssl-dev \
-    libreadline-dev \
-    libffi-dev \
-    libsqlite3-dev \
-    libbz2-dev \
+    software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y \
+    python3.11 \
+    python3.11-venv \
+    python3.11-dev \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Download and compile Python 3.11.13
-RUN wget https://www.python.org/ftp/python/3.11.13/Python-3.11.13.tgz \
-    && tar -xzf Python-3.11.13.tgz \
-    && cd Python-3.11.13 \
-    && ./configure --enable-optimizations \
-    && make -j$(nproc) \
-    && make altinstall \
-    && cd .. \
-    && rm -rf Python-3.11.13.tgz Python-3.11.13
-
 # Create symlinks
-RUN ln -s /usr/local/bin/python3.11 /usr/local/bin/python \
-    && ln -s /usr/local/bin/pip3.11 /usr/local/bin/pip
+RUN ln -s /usr/bin/python3.11 /usr/bin/python \
+    && ln -s /usr/bin/python3.11 /usr/bin/python3
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ARG conda=/opt/conda/bin/${CONDA_MANAGER}
 ARG PYTHON_VERSION=3.11.13
 # install miniconda
-RUN wget ${CONDA_URL} -O /miniconda3/miniconda.sh && \
+RUN mkdir -p /miniconda3 && \
+    wget ${CONDA_URL} -O /miniconda3/miniconda.sh && \
     /miniconda3/miniconda.sh -b -u -p /miniconda3 && \
     rm /miniconda3/miniconda.sh
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -60,12 +60,18 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
 
 # Make RUN commands use the new environment
-# SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
 RUN echo "3sdfskdjfgl"  && \
     sleep 5 && \
     echo "3YYYYYYYsYYa"  &&\
     sleep 5 && \
     echo "3YYYYYYYsYYa" 
+
+SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
+RUN echo "sdfskdjfgl"  && \
+    sleep 5 && \
+    echo "34YYYYYYYsYYa"  &&\
+    sleep 5 && \
+    echo "34YYYYYYYsYYa" 
 
 WORKDIR /opt/pytorch
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -68,5 +68,5 @@ WORKDIR /
 # RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
 #     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
-FROM wheel-builder AS export
-COPY --from=wheel-builder /tmp/dist /dist/wheels
+# FROM wheel-builder AS export
+# COPY --from=wheel-builder /tmp/dist /dist/wheels

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -64,7 +64,7 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
 # install the wheel and verify torch imports and runs a basic op
 # python -m pip install --no-build-isolation -v .
-RUN pip install -no-build-isolation -v --no-index --find-links=/tmp/dist torch && \
+RUN pip install --no-build-isolation -v --no-index --find-links=/tmp/dist torch && \
     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -92,7 +92,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 #     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 COPY ./test-torch-vision-nms.py /test-torch-vision-nms.py
-RUN ls /tmp/dist && python -m pip install /tmp/dist/torch_vision-0.23.0-cp311-cp311-linux_aarch64.whl && \
+RUN ls /tmp/dist && python -m pip install /tmp/dist/torchvision-0.23.0a0+824e8c8-cp311-cp311-linux_aarch64.whl && \
     python /test-torch-vision-nms.py
 
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -64,6 +64,7 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
 # install the wheel and verify torch imports and runs a basic op
 # python -m pip install --no-build-isolation -v .
+WORKDIR /
 RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -26,9 +26,8 @@ RUN mkdir -p /miniconda3 && \
 
 # /miniconda3/bin/activate in all future RUN commands
 ENV PATH="/miniconda3/bin:$PATH"
-RUN 
-     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
-     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
+RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r && \
     conda install python=${PYTHON_VERSION} && \
     conda clean -fya && rm -rf /tmp/conda/miniconda.sh && \
     find /miniconda3 -type d -name '__pycache__' | xargs rm -rf

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -2,11 +2,13 @@ FROM nvidia/cuda:13.0.1-cudnn-devel-ubuntu22.04
 
 ARG PYTORCH_VERSION_TAG=v2.8.0
 ARG TORCH_URL=https://github.com/pytorch/pytorch.git
-
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
 # Install git 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl \
     && rm -rf /var/lib/apt/lists/*
+
 
 RUN apt-get update && apt-get install -y \
     software-properties-common \

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -33,6 +33,8 @@ RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkg
     find /miniconda3 -type d -name '__pycache__' | xargs rm -rf
 
 
+RUN ls /miniconda3/envs && exit 1
+
 
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -11,8 +11,7 @@ WORKDIR /tmp/conda
 
 ARG conda=/opt/conda/bin/${CONDA_MANAGER}
 ARG PYTHON_VERSION=3.11.13
-RUN --mount=type=bind,from=curl-conda,source=/tmp/conda,target=/tmp/conda \
-    /bin/bash /tmp/conda/miniconda.sh -b -p /opt/conda && \
+RUN /bin/bash /tmp/conda/miniconda.sh -b -p /opt/conda && \
     printf "channels:\n  - conda-forge\n  - nodefaults\nssl_verify: false\n" > /opt/conda/.condarc && \
     $conda install -y python=${PYTHON_VERSION} && $conda clean -fya && \
     find /opt/conda -type d -name '__pycache__' | xargs rm -rf

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -38,9 +38,6 @@ RUN /miniconda3/bin/conda init bash && \
     /miniconda3/bin/conda create -n py311 python=3.11 -y
 
 
-RUN ls /miniconda3/envs && exit 1
-
-
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update && apt-get install -y \
 
 # Create symlinks
 RUN ln -s /usr/bin/python3.11 /usr/bin/python \
-    && ln -s /usr/bin/python3.11 /usr/bin/python3
 
 # Minimize downloads by only cloning shallow branches and not the full `git` history.
 # Use at most 8 jobs for cloning the repository and its submodules.

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -91,7 +91,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 # RUN python -m pip install /tmp/dist/torch-2.9.0a0+gitc31a818-cp311-cp311-linux_aarch64.whl && \
 #     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
-COPY ./test-torch-vision-nms.py /
+COPY test-torch-vision-nms.py /
 RUN python -m pip install /tmp/dist/torch_vision-0.23.0-cp311-cp311-linux_aarch64.whl && \
     python /test-torch-vision-nms.py
 

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -59,9 +59,5 @@ RUN cat pyproject.toml && pip install --group dev
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
 ENV PYTHONUNBUFFERED=1
-RUN echo "sdfskdjfgl"  && \
-    sync && \
-    sleep 5 && \
-    echo "YYYYYYYsYYa"  
-# && \
-# VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
+
+RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -64,8 +64,8 @@ RUN VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist
 
 # install the wheel and verify torch imports and runs a basic op
 
-RUN pip install --no-index --find-links=/dist/wheels torch && \
-    python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
+# RUN pip install --no-index --find-links=/dist/wheels torch && \
+#     python -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); x = torch.rand(5, 3); print(x)"
 
 FROM wheel-builder AS export
 COPY --from=wheel-builder /tmp/dist /dist/wheels

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -61,8 +61,8 @@ RUN cat pyproject.toml && pip install --group dev
 
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?
 # ARG BUILD_LIBTORCH_WHL=1
-RUN python -c "print ('XXXXXXX')"  && \
-sleep 10 && \
-echo "YYYYYYYsYY" 
+RUN echo "sdfskdjfgl"  && \
+sleep 5 && \
+echo "YYYYYYYsYY"  
 # && \
 # VERBOSE_SCRIPT=true python setup.py bdist_wheel -d /tmp/dist

--- a/dockerfiles/minimal.Dockerfile
+++ b/dockerfiles/minimal.Dockerfile
@@ -42,7 +42,7 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
         --branch ${PYTORCH_VERSION_TAG} ${TORCH_URL} /opt/pytorch
 
 # Make RUN commands use the new environment
-SHELL ["/opt/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
+SHELL ["/miniconda3/bin/conda", "run", "-n", "py311", "/bin/bash", "-c"]
 
 WORKDIR /opt/pytorch
 ARG TORCH_CUDA_ARCH_LIST="11.0" # +PTX?

--- a/dockerfiles/test-torch-vision-nms.py
+++ b/dockerfiles/test-torch-vision-nms.py
@@ -1,0 +1,44 @@
+import torch
+
+
+def check_environment() -> None:
+   """Check the environment for potential issues"""
+   print('Environment Check:')
+   print(f'PyTorch CUDA available: {torch.cuda.is_available()}')
+
+
+   if torch.cuda.is_available():
+       print(f'PyTorch CUDA version: {torch.version.cuda}')
+       print(f'Detected CUDA devices: {torch.cuda.device_count()}')
+
+
+       # Try a simple CUDA operation
+       try:
+           x = torch.randn(2, 2).cuda()
+           y = torch.randn(2, 2).cuda()
+           z = torch.mm(x, y)
+           print('Basic CUDA operations work')
+       except Exception as e:
+           print(f'Basic CUDA operations failed: {e}')
+
+
+   # Check if torchvision ops work
+   try:
+       from torchvision.ops import nms
+
+
+       boxes = torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1]], dtype=torch.float32)
+       scores = torch.tensor([0.9, 0.8], dtype=torch.float32)
+
+
+       if torch.cuda.is_available():
+           boxes = boxes.cuda()
+           scores = scores.cuda()
+
+
+       keep = nms(boxes, scores, 0.5)
+       print('torchvision.ops.nms works on current device')	
+   except Exception as e:
+       print(f'torchvision.ops.nms failed: {e}')
+if __name__ == '__main__':
+   check_environment()

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   python setup.py -v -v bdist_wheel --verbose -d /tmp/dist
+   USE_SYSTEM_NCCL=1 python setup.py -v -v bdist_wheel --verbose -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -219,7 +219,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # Install PyTorch for subsidiary libraries (e.g., TorchVision).
 # " we strongly recommend enabling linker script optimization for ARM + CUDA"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
-RUN ld -verbose
+# RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=1
 RUN --mount=type=cache,target=/opt/ccache \
     python setup.py bdist_wheel -d /tmp/dist && \

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -228,7 +228,7 @@ RUN --mount=type=cache,target=/opt/ccache \
     VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
     
 RUN python -m trace -t setup.py install
-
+RUN python setup.py install
 RUN pip list; exit 1
 
 ###### Additional information for custom builds. ######

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   USE_SYSTEM_NCCL=1 python setup.py -v -v bdist_wheel --verbose -d /tmp/dist
+   MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py -v -v bdist_wheel --verbose -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -217,6 +217,9 @@ ARG TORCH_CUDA_ARCH_LIST
 ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # Build wheel for installation in later stages.
 # Install PyTorch for subsidiary libraries (e.g., TorchVision).
+# " we strongly recommend enabling linker script optimization for ARM + CUDA"
+# To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
+ARG USE_PRIORITIZED_TEXT_FOR_LD 
 RUN --mount=type=cache,target=/opt/ccache \
     python setup.py bdist_wheel -d /tmp/dist && \
     python setup.py install
@@ -302,7 +305,7 @@ ARG USE_CUDA
 ARG USE_PRECOMPILED_HEADERS
 ARG FORCE_CUDA=${USE_CUDA}
 ARG TORCH_CUDA_ARCH_LIST
-RUN --mount=type=cache,target=/opt/ccache \
+RUN --mount=type=cache,target=/opt/ccache \:g22
     python setup.py bdist_wheel -d /tmp/dist
 
 ########################################################################

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,7 +225,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
     echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
-    USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m --trace setup.py bdist_wheel -d /tmp/dist 
+    USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,7 +225,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
     echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
-    USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
+    VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -223,7 +223,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # RUN python -c "print('X')" && exit 1
 
-RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
+# RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -392,7 +392,7 @@ FROM ${BUILD_IMAGE} AS train-builds-include
 # with only the build artifacts (e.g., pip wheels) copied over.
 COPY --link --from=install-conda /opt/conda /opt/conda
 COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
-COPY --link --from=build-vision  /tmp/dist  /tmp/dist
+# COPY --link --from=build-vision  /tmp/dist  /tmp/dist
 COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
 
 ########################################################################

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -228,6 +228,8 @@ RUN --mount=type=cache,target=/opt/ccache \
     VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
     
 RUN python -m trace -t setup.py install
+ARG VERBOSE=1
+ARG MAX_JOBS=1  
 RUN   VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1  python setup.py install
 RUN pip list; exit 1
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -305,7 +305,7 @@ ARG USE_CUDA
 ARG USE_PRECOMPILED_HEADERS
 ARG FORCE_CUDA=${USE_CUDA}
 ARG TORCH_CUDA_ARCH_LIST
-RUN --mount=type=cache,target=/opt/ccache \:g22
+RUN --mount=type=cache,target=/opt/ccache \
     python setup.py bdist_wheel -d /tmp/dist
 
 ########################################################################

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,7 +225,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
     echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
-    VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
+    VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py --build bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,7 +225,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
     echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
-    USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python --trace setup.py bdist_wheel -d /tmp/dist 
+    USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m --trace setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,10 +224,11 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # RUN python -c "print('X')" && exit 1
 
 # RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
+RUN /bin/bash
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -X faulthandler setup.py bdist_wheel -d /tmp/dist; exit 1
+   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py bdist_wheel -d /tmp/dist; exit 1
 
 ENTRYPOINT [ "/bin/bash" ]
     

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -310,8 +310,8 @@ ARG USE_CUDA
 ARG USE_PRECOMPILED_HEADERS
 ARG FORCE_CUDA=${USE_CUDA}
 ARG TORCH_CUDA_ARCH_LIST
-RUN --mount=type=cache,target=/opt/ccache \
-    python -m trace -t setup.py bdist_wheel -d /tmp/dist
+# RUN --mount=type=cache,target=/opt/ccache \
+#     python setup.py bdist_wheel -d /tmp/dist
 
 ########################################################################
 FROM ${GIT_IMAGE} AS fetch-pure

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -219,7 +219,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # Install PyTorch for subsidiary libraries (e.g., TorchVision).
 # " we strongly recommend enabling linker script optimization for ARM + CUDA"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
-RUN which ld
+RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=1
 RUN --mount=type=cache,target=/opt/ccache \
     python setup.py bdist_wheel -d /tmp/dist && \

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -310,8 +310,9 @@ ARG USE_CUDA
 ARG USE_PRECOMPILED_HEADERS
 ARG FORCE_CUDA=${USE_CUDA}
 ARG TORCH_CUDA_ARCH_LIST
-# RUN --mount=type=cache,target=/opt/ccache \
-#     python setup.py bdist_wheel -d /tmp/dist
+RUN --mount=type=cache,target=/opt/ccache \
+    cat setup.py && \
+    python setup.py bdist_wheel -d /tmp/dist
 
 ########################################################################
 FROM ${GIT_IMAGE} AS fetch-pure

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,8 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-    echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
-    VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
+   python setup.py bdist_wheel -d /tmp/dist 
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -311,7 +311,7 @@ ARG USE_PRECOMPILED_HEADERS
 ARG FORCE_CUDA=${USE_CUDA}
 ARG TORCH_CUDA_ARCH_LIST
 RUN --mount=type=cache,target=/opt/ccache \
-    python setup.py bdist_wheel -d /tmp/dist
+    python -m trace -t setup.py bdist_wheel -d /tmp/dist
 
 ########################################################################
 FROM ${GIT_IMAGE} AS fetch-pure

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -311,7 +311,7 @@ ARG USE_PRECOMPILED_HEADERS
 ARG FORCE_CUDA=${USE_CUDA}
 ARG TORCH_CUDA_ARCH_LIST
 RUN --mount=type=cache,target=/opt/ccache \
-    cat setup.py && \
+    pwd; cat setup.py && \
     python setup.py bdist_wheel -d /tmp/dist
 
 ########################################################################

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -222,9 +222,9 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
+# cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-    cat setup.py && \
-    MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
+    USE_SYSTEM_NCCL=0 CMAKE_FRESH=1 MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   python setup.py bdist_wheel -d /tmp/dist
+   python setup.py bdist_wheel -v -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   python setup.py -v bdist_wheel --verbose -d /tmp/dist
+   python setup.py -v -v bdist_wheel --verbose -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   python setup.py bdist_wheel --verbose -d /tmp/dist
+   python setup.py -v bdist_wheel --verbose -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   python -m trace -t setup.py bdist_wheel -d /tmp/dist && exit 1
+   python setup.py bdist_wheel -d /tmp/dist && exit 1
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -221,7 +221,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
-RUN pip list; exit 1
+# RUN pip list; exit 1
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -229,6 +229,8 @@ RUN --mount=type=cache,target=/opt/ccache \
     
 RUN python -m trace -t setup.py install
 
+RUN pip list; exit 1
+
 ###### Additional information for custom builds. ######
 
 # Use the following to build with custom CMake settings.

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   python setup.py bdist_wheel -d /tmp/dist 
+   python -m trace -t setup.py bdist_wheel -d /tmp/dist && exit 1
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -136,8 +136,9 @@ RUN --mount=type=cache,target=${CONDA_PKGS_DIRS},sharing=locked \
     elif [ "${MKL_MODE}" = "exclude" ]; then \
       echo 'nomkl' >> ${BUILD_REQS}; \
     else echo "Invalid `MKL_MODE`: ${MKL_MODE}." && exit -1; fi && \
-    echo "pytorch::magma-cuda$(echo ${CUDA_VERSION} | sed 's/\.//; s/\..*//')" >> ${BUILD_REQS} && \
-    $conda install -y --file ${BUILD_REQS}
+    $conda install -y --file ${BUILD_REQS}   
+#echo "pytorch::magma-cuda$(echo ${CUDA_VERSION} | sed 's/\.//; s/\..*//')" >> ${BUILD_REQS} && \
+#    $conda install -y --file ${BUILD_REQS}
 
 # Use Jemalloc as the system memory allocator for efficient memory management.
 ENV LD_PRELOAD=/opt/conda/lib/libjemalloc.so${LD_PRELOAD:+:${LD_PRELOAD}}
@@ -263,10 +264,18 @@ RUN $conda install -y libjpeg-turbo zlib && $conda clean -fya
 ARG PILLOW_SIMD_VERSION
 # The condition ensures that AVX2 instructions are built only if available.
 # May cause issues if the image is used on a machine with a different SIMD ISA.
-RUN if [ ! "$(lscpu | grep -q avx2)" ]; then CC="cc -mavx2"; fi && \
-    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
-        Pillow-SIMD${PILLOW_SIMD_VERSION}
+#RUN if [ ! "$(lscpu | grep -q avx2)" ]; then CC="cc -mavx2"; fi && \
+#    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
+#        Pillow-SIMD${PILLOW_SIMD_VERSION}
 
+ARG USE_PILLOW_SIMD=false
+RUN if [ "$USE_PILLOW_SIMD" = "false" ] || [ "$(uname -m)" = "aarch64" ]; then \
+        PILLOW_PACKAGE="Pillow"; \
+    else \
+        PILLOW_PACKAGE="Pillow-SIMD"; \
+    fi && \
+    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
+        ${PILLOW_PACKAGE}${PILLOW_SIMD_VERSION}
 ########################################################################
 FROM ${GIT_IMAGE} AS clone-vision
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -228,7 +228,7 @@ RUN --mount=type=cache,target=/opt/ccache \
     VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
     
 RUN python -m trace -t setup.py install
-RUN python setup.py install
+RUN python  VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1  setup.py install
 RUN pip list; exit 1
 
 ###### Additional information for custom builds. ######

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -221,6 +221,8 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
+RUN python -c "print('X')" && exit 1
+
 RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
 
 # cat setup.py && \

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,18 +224,17 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # RUN python -c "print('X')" && exit 1
 
 # RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
-# RUN /bin/bash
 
-# # cat setup.py && \
-# RUN --mount=type=cache,target=/opt/ccache \
-#    CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py bdist_wheel -d /tmp/dist; exit 1
+# cat setup.py && \
+RUN --mount=type=cache,target=/opt/ccache \
+   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -X faulthandler setup.py bdist_wheel -d /tmp/dist; exit 1
 
 ENTRYPOINT [ "/bin/bash" ]
     
-# ARG VERBOSE=1
-# ARG MAX_JOBS=1  
-# RUN python setup.py install
-# RUN pip list; exit 1
+ARG VERBOSE=1
+ARG MAX_JOBS=1  
+RUN python setup.py install
+RUN pip list; exit 1
 
 ###### Additional information for custom builds. ######
 
@@ -305,23 +304,24 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 ########################################################################
 FROM build-torch AS build-vision
 
-# WORKDIR /opt/vision
-# COPY --link --from=clone-vision /opt/vision /opt/vision
+WORKDIR /opt/vision
+COPY --link --from=clone-vision /opt/vision /opt/vision
 
+RUN pip list; exit 1
 
-# # Install Pillow-SIMD before TorchVision build and add it to `/tmp/dist`.
-# # Pillow will be uninstalled if it is present.
-# RUN --mount=type=bind,from=build-pillow,source=/tmp/dist,target=/tmp/dist \
-#     python -m pip install --no-deps /tmp/dist/*
-# # python -m pip uninstall -y pillow && \
+# Install Pillow-SIMD before TorchVision build and add it to `/tmp/dist`.
+# Pillow will be uninstalled if it is present.
+RUN --mount=type=bind,from=build-pillow,source=/tmp/dist,target=/tmp/dist \
+    python -m pip install --no-deps /tmp/dist/*
+# python -m pip uninstall -y pillow && \
 
-# ARG USE_CUDA
-# ARG USE_PRECOMPILED_HEADERS
-# ARG FORCE_CUDA=${USE_CUDA}
-# ARG TORCH_CUDA_ARCH_LIST
-# RUN --mount=type=cache,target=/opt/ccache \
-#     pwd; cat setup.py && \
-#     python setup.py bdist_wheel -d /tmp/dist
+ARG USE_CUDA
+ARG USE_PRECOMPILED_HEADERS
+ARG FORCE_CUDA=${USE_CUDA}
+ARG TORCH_CUDA_ARCH_LIST
+RUN --mount=type=cache,target=/opt/ccache \
+    pwd; cat setup.py && \
+    python setup.py bdist_wheel -d /tmp/dist
 
 ########################################################################
 FROM ${GIT_IMAGE} AS fetch-pure
@@ -392,7 +392,7 @@ FROM ${BUILD_IMAGE} AS train-builds-include
 # with only the build artifacts (e.g., pip wheels) copied over.
 COPY --link --from=install-conda /opt/conda /opt/conda
 COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
-# COPY --link --from=build-vision  /tmp/dist  /tmp/dist
+COPY --link --from=build-vision  /tmp/dist  /tmp/dist
 COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
 
 ########################################################################

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,18 +224,18 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # RUN python -c "print('X')" && exit 1
 
 # RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
-RUN /bin/bash
+# RUN /bin/bash
 
-# cat setup.py && \
-RUN --mount=type=cache,target=/opt/ccache \
-   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py bdist_wheel -d /tmp/dist; exit 1
+# # cat setup.py && \
+# RUN --mount=type=cache,target=/opt/ccache \
+#    CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py bdist_wheel -d /tmp/dist; exit 1
 
 ENTRYPOINT [ "/bin/bash" ]
     
-ARG VERBOSE=1
-ARG MAX_JOBS=1  
-RUN python setup.py install
-RUN pip list; exit 1
+# ARG VERBOSE=1
+# ARG MAX_JOBS=1  
+# RUN python setup.py install
+# RUN pip list; exit 1
 
 ###### Additional information for custom builds. ######
 
@@ -305,24 +305,23 @@ RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
 ########################################################################
 FROM build-torch AS build-vision
 
-WORKDIR /opt/vision
-COPY --link --from=clone-vision /opt/vision /opt/vision
+# WORKDIR /opt/vision
+# COPY --link --from=clone-vision /opt/vision /opt/vision
 
-RUN pip list; exit 1
 
-# Install Pillow-SIMD before TorchVision build and add it to `/tmp/dist`.
-# Pillow will be uninstalled if it is present.
-RUN --mount=type=bind,from=build-pillow,source=/tmp/dist,target=/tmp/dist \
-    python -m pip install --no-deps /tmp/dist/*
-# python -m pip uninstall -y pillow && \
+# # Install Pillow-SIMD before TorchVision build and add it to `/tmp/dist`.
+# # Pillow will be uninstalled if it is present.
+# RUN --mount=type=bind,from=build-pillow,source=/tmp/dist,target=/tmp/dist \
+#     python -m pip install --no-deps /tmp/dist/*
+# # python -m pip uninstall -y pillow && \
 
-ARG USE_CUDA
-ARG USE_PRECOMPILED_HEADERS
-ARG FORCE_CUDA=${USE_CUDA}
-ARG TORCH_CUDA_ARCH_LIST
-RUN --mount=type=cache,target=/opt/ccache \
-    pwd; cat setup.py && \
-    python setup.py bdist_wheel -d /tmp/dist
+# ARG USE_CUDA
+# ARG USE_PRECOMPILED_HEADERS
+# ARG FORCE_CUDA=${USE_CUDA}
+# ARG TORCH_CUDA_ARCH_LIST
+# RUN --mount=type=cache,target=/opt/ccache \
+#     pwd; cat setup.py && \
+#     python setup.py bdist_wheel -d /tmp/dist
 
 ########################################################################
 FROM ${GIT_IMAGE} AS fetch-pure

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,7 +225,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py bdist_wheel -d /tmp/dist
+   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -226,366 +226,365 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
 
 # cat setup.py && \
-# RUN --mount=type=cache,target=/opt/ccache \
-#    CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist; exit 1
+RUN --mount=type=cache,target=/opt/ccache \
+   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -X faulthandler setup.py bdist_wheel -d /tmp/dist; exit 1
 
 ENTRYPOINT [ "/bin/bash" ]
-
     
-# ARG VERBOSE=1
-# ARG MAX_JOBS=1  
-# RUN python setup.py install
-# RUN pip list; exit 1
+ARG VERBOSE=1
+ARG MAX_JOBS=1  
+RUN python setup.py install
+RUN pip list; exit 1
 
-# ###### Additional information for custom builds. ######
+###### Additional information for custom builds. ######
 
-# # Use the following to build with custom CMake settings.
-# #RUN --mount=type=cache,target=/opt/ccache \
-# #    python setup.py build --cmake-only && \
-# #    ccmake build  # or cmake-gui build
+# Use the following to build with custom CMake settings.
+#RUN --mount=type=cache,target=/opt/ccache \
+#    python setup.py build --cmake-only && \
+#    ccmake build  # or cmake-gui build
 
-# # Visit the Setuptools documentation for more `setup.py` options.
-# # https://setuptools.pypa.io/en/latest
+# Visit the Setuptools documentation for more `setup.py` options.
+# https://setuptools.pypa.io/en/latest
 
-# # C++ developers using Libtorch can find the library in
-# # `torch/lib/tmp_install/lib/libtorch.so`.
+# C++ developers using Libtorch can find the library in
+# `torch/lib/tmp_install/lib/libtorch.so`.
 
-# # The default configuration removes all files except requirements files from the Docker context.
-# # To `COPY` your source files during the build, please edit the `.dockerignore` file.
+# The default configuration removes all files except requirements files from the Docker context.
+# To `COPY` your source files during the build, please edit the `.dockerignore` file.
 
-# # A detailed (if out of date) explanation of the buildsystem can be found below.
-# # https://pytorch.org/blog/a-tour-of-pytorch-internals-2
-# # The following repository may also be helpful for available options and possible issues.
-# # https://github.com/mratsim/Arch-Data-Science/blob/master/frameworks/python-pytorch-magma-mkldnn-cudnn-git/PKGBUILD
+# A detailed (if out of date) explanation of the buildsystem can be found below.
+# https://pytorch.org/blog/a-tour-of-pytorch-internals-2
+# The following repository may also be helpful for available options and possible issues.
+# https://github.com/mratsim/Arch-Data-Science/blob/master/frameworks/python-pytorch-magma-mkldnn-cudnn-git/PKGBUILD
 
-# # Manually specify conda package versions if older PyTorch versions will not build.
-# # PyYAML, MKL-DNN, and Setuptools are known culprits.
+# Manually specify conda package versions if older PyTorch versions will not build.
+# PyYAML, MKL-DNN, and Setuptools are known culprits.
 
-# # Run the command below before building to enable ROCM builds.
-# # RUN python tools/amd_build/build_amd.py
-# # PyTorch builds with ROCM have not been tested.
-# # Note that PyTorch for ROCM is still in beta and the ROCM build API may change.
+# Run the command below before building to enable ROCM builds.
+# RUN python tools/amd_build/build_amd.py
+# PyTorch builds with ROCM have not been tested.
+# Note that PyTorch for ROCM is still in beta and the ROCM build API may change.
 
-# # To build for Jetson Nano devices, see the link below for the necessary modifications.
-# # https://forums.developer.nvidia.com/t/pytorch-for-jetson-version-1-10-now-available/72048
+# To build for Jetson Nano devices, see the link below for the necessary modifications.
+# https://forums.developer.nvidia.com/t/pytorch-for-jetson-version-1-10-now-available/72048
 
-# ########################################################################
-# FROM install-conda AS build-pillow
-# # This stage is derived from `install-conda` instead of `build-base`
-# # as it is very lightweight and does not require many dependencies.
-# RUN $conda install -y libjpeg-turbo zlib && $conda clean -fya
+########################################################################
+FROM install-conda AS build-pillow
+# This stage is derived from `install-conda` instead of `build-base`
+# as it is very lightweight and does not require many dependencies.
+RUN $conda install -y libjpeg-turbo zlib && $conda clean -fya
 
-# # Specify the `Pillow-SIMD` version if necessary. The variable is not used yet.
-# # Set as `PILLOW_SIMD_VERSION="==VERSION_NUMBER"` for use in the current setup.
-# ARG PILLOW_SIMD_VERSION
-# # The condition ensures that AVX2 instructions are built only if available.
-# # May cause issues if the image is used on a machine with a different SIMD ISA.
-# #RUN if [ ! "$(lscpu | grep -q avx2)" ]; then CC="cc -mavx2"; fi && \
-# #    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
-# #        Pillow-SIMD${PILLOW_SIMD_VERSION}
+# Specify the `Pillow-SIMD` version if necessary. The variable is not used yet.
+# Set as `PILLOW_SIMD_VERSION="==VERSION_NUMBER"` for use in the current setup.
+ARG PILLOW_SIMD_VERSION
+# The condition ensures that AVX2 instructions are built only if available.
+# May cause issues if the image is used on a machine with a different SIMD ISA.
+#RUN if [ ! "$(lscpu | grep -q avx2)" ]; then CC="cc -mavx2"; fi && \
+#    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
+#        Pillow-SIMD${PILLOW_SIMD_VERSION}
 
-# ## Use Pillow-SIMD if available and not on aarch64
-# ARG USE_PILLOW_SIMD=false
-# RUN if [ "$USE_PILLOW_SIMD" = "false" ] || [ "$(uname -m)" = "aarch64" ]; then \
-#         PILLOW_PACKAGE="Pillow"; \
-#     else \
-#         PILLOW_PACKAGE="Pillow-SIMD"; \
-#     fi && \
-#     python -m pip wheel --no-deps --wheel-dir /tmp/dist \
-#         ${PILLOW_PACKAGE}${PILLOW_SIMD_VERSION}
-# ########################################################################
-# FROM ${GIT_IMAGE} AS clone-vision
+## Use Pillow-SIMD if available and not on aarch64
+ARG USE_PILLOW_SIMD=false
+RUN if [ "$USE_PILLOW_SIMD" = "false" ] || [ "$(uname -m)" = "aarch64" ]; then \
+        PILLOW_PACKAGE="Pillow"; \
+    else \
+        PILLOW_PACKAGE="Pillow-SIMD"; \
+    fi && \
+    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
+        ${PILLOW_PACKAGE}${PILLOW_SIMD_VERSION}
+########################################################################
+FROM ${GIT_IMAGE} AS clone-vision
 
-# ARG TORCHVISION_VERSION_TAG
-# ARG VISION_URL=https://github.com/pytorch/vision.git
-# RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
-#         --single-branch --shallow-submodules --recurse-submodules \
-#         --branch ${TORCHVISION_VERSION_TAG} ${VISION_URL} /opt/vision
+ARG TORCHVISION_VERSION_TAG
+ARG VISION_URL=https://github.com/pytorch/vision.git
+RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
+        --single-branch --shallow-submodules --recurse-submodules \
+        --branch ${TORCHVISION_VERSION_TAG} ${VISION_URL} /opt/vision
 
-# ########################################################################
-# FROM build-torch AS build-vision
+########################################################################
+FROM build-torch AS build-vision
 
-# WORKDIR /opt/vision
-# COPY --link --from=clone-vision /opt/vision /opt/vision
+WORKDIR /opt/vision
+COPY --link --from=clone-vision /opt/vision /opt/vision
 
-# RUN pip list; exit 1
+RUN pip list; exit 1
 
-# # Install Pillow-SIMD before TorchVision build and add it to `/tmp/dist`.
-# # Pillow will be uninstalled if it is present.
-# RUN --mount=type=bind,from=build-pillow,source=/tmp/dist,target=/tmp/dist \
-#     python -m pip install --no-deps /tmp/dist/*
-# # python -m pip uninstall -y pillow && \
+# Install Pillow-SIMD before TorchVision build and add it to `/tmp/dist`.
+# Pillow will be uninstalled if it is present.
+RUN --mount=type=bind,from=build-pillow,source=/tmp/dist,target=/tmp/dist \
+    python -m pip install --no-deps /tmp/dist/*
+# python -m pip uninstall -y pillow && \
 
-# ARG USE_CUDA
-# ARG USE_PRECOMPILED_HEADERS
-# ARG FORCE_CUDA=${USE_CUDA}
-# ARG TORCH_CUDA_ARCH_LIST
-# RUN --mount=type=cache,target=/opt/ccache \
-#     pwd; cat setup.py && \
-#     python setup.py bdist_wheel -d /tmp/dist
+ARG USE_CUDA
+ARG USE_PRECOMPILED_HEADERS
+ARG FORCE_CUDA=${USE_CUDA}
+ARG TORCH_CUDA_ARCH_LIST
+RUN --mount=type=cache,target=/opt/ccache \
+    pwd; cat setup.py && \
+    python setup.py bdist_wheel -d /tmp/dist
 
-# ########################################################################
-# FROM ${GIT_IMAGE} AS fetch-pure
+########################################################################
+FROM ${GIT_IMAGE} AS fetch-pure
 
-# # Z-Shell related libraries.
-# ARG PURE_URL=https://github.com/sindresorhus/pure.git
-# ARG ZSHA_URL=https://github.com/zsh-users/zsh-autosuggestions
-# ARG ZSHS_URL=https://github.com/zsh-users/zsh-syntax-highlighting.git
+# Z-Shell related libraries.
+ARG PURE_URL=https://github.com/sindresorhus/pure.git
+ARG ZSHA_URL=https://github.com/zsh-users/zsh-autosuggestions
+ARG ZSHS_URL=https://github.com/zsh-users/zsh-syntax-highlighting.git
 
-# RUN git clone --depth 1 ${PURE_URL} /opt/zsh/pure
-# RUN git clone --depth 1 ${ZSHA_URL} /opt/zsh/zsh-autosuggestions
-# RUN git clone --depth 1 ${ZSHS_URL} /opt/zsh/zsh-syntax-highlighting
+RUN git clone --depth 1 ${PURE_URL} /opt/zsh/pure
+RUN git clone --depth 1 ${ZSHA_URL} /opt/zsh/zsh-autosuggestions
+RUN git clone --depth 1 ${ZSHS_URL} /opt/zsh/zsh-syntax-highlighting
 
-# ########################################################################
-# FROM install-conda AS fetch-torch
+########################################################################
+FROM install-conda AS fetch-torch
 
-# # For users who wish to download wheels instead of building them.
-# ARG PYTORCH_INDEX_URL
-# ARG PYTORCH_FETCH_NIGHTLY
-# ARG PYTORCH_VERSION
-# RUN if [ -z ${PYTORCH_FETCH_NIGHTLY} ]; then \
-#         python -m pip wheel \
-#             --no-deps --wheel-dir /tmp/dist \
-#             --index-url ${PYTORCH_INDEX_URL} \
-#             torch==${PYTORCH_VERSION}; \
-#     else \
-#         python -m pip wheel --pre \
-#             --no-deps --wheel-dir /tmp/dist \
-#             --index-url ${PYTORCH_INDEX_URL} \
-#             torch; \
-#     fi
+# For users who wish to download wheels instead of building them.
+ARG PYTORCH_INDEX_URL
+ARG PYTORCH_FETCH_NIGHTLY
+ARG PYTORCH_VERSION
+RUN if [ -z ${PYTORCH_FETCH_NIGHTLY} ]; then \
+        python -m pip wheel \
+            --no-deps --wheel-dir /tmp/dist \
+            --index-url ${PYTORCH_INDEX_URL} \
+            torch==${PYTORCH_VERSION}; \
+    else \
+        python -m pip wheel --pre \
+            --no-deps --wheel-dir /tmp/dist \
+            --index-url ${PYTORCH_INDEX_URL} \
+            torch; \
+    fi
 
-# ########################################################################
-# FROM install-conda AS fetch-vision
+########################################################################
+FROM install-conda AS fetch-vision
 
-# ARG PYTORCH_INDEX_URL
-# ARG PYTORCH_FETCH_NIGHTLY
-# ARG TORCHVISION_VERSION
-# RUN if [ -z ${PYTORCH_FETCH_NIGHTLY} ]; then \
-#         python -m pip wheel \
-#             --no-deps --wheel-dir /tmp/dist \
-#             --index-url ${PYTORCH_INDEX_URL} \
-#             torchvision==${TORCHVISION_VERSION}; \
-#     else \
-#         python -m pip wheel --pre \
-#             --no-deps --wheel-dir /tmp/dist \
-#             --index-url ${PYTORCH_INDEX_URL} \
-#             torchvision; \
-#     fi
+ARG PYTORCH_INDEX_URL
+ARG PYTORCH_FETCH_NIGHTLY
+ARG TORCHVISION_VERSION
+RUN if [ -z ${PYTORCH_FETCH_NIGHTLY} ]; then \
+        python -m pip wheel \
+            --no-deps --wheel-dir /tmp/dist \
+            --index-url ${PYTORCH_INDEX_URL} \
+            torchvision==${TORCHVISION_VERSION}; \
+    else \
+        python -m pip wheel --pre \
+            --no-deps --wheel-dir /tmp/dist \
+            --index-url ${PYTORCH_INDEX_URL} \
+            torchvision; \
+    fi
 
-# ########################################################################
-# FROM ${BUILD_IMAGE} AS train-stash
+########################################################################
+FROM ${BUILD_IMAGE} AS train-stash
 
-# # This stage prevents direct contact between the `train` stage and external files.
-# # Other files such as `.deb` package files may also be stashed here.
-# COPY --link ../reqs/train-apt.requirements.txt /tmp/apt/requirements.txt
+# This stage prevents direct contact between the `train` stage and external files.
+# Other files such as `.deb` package files may also be stashed here.
+COPY --link ../reqs/train-apt.requirements.txt /tmp/apt/requirements.txt
 
-# ########################################################################
-# FROM ${BUILD_IMAGE} AS train-builds-include
-# # A convenience stage to gather build artifacts (wheels, etc.) for the train stage.
-# # If other source builds are included later on, gather them here as well.
-# # All pip wheels are located in `/tmp/dist`.
-# # Using an image other than `BUILD_IMAGE` may contaminate
-# # `/opt/conda` and other key directories.
+########################################################################
+FROM ${BUILD_IMAGE} AS train-builds-include
+# A convenience stage to gather build artifacts (wheels, etc.) for the train stage.
+# If other source builds are included later on, gather them here as well.
+# All pip wheels are located in `/tmp/dist`.
+# Using an image other than `BUILD_IMAGE` may contaminate
+# `/opt/conda` and other key directories.
 
-# # The `train` stage is the one actually used for training.
-# # It is designed to be separate from the `build` stage,
-# # with only the build artifacts (e.g., pip wheels) copied over.
-# COPY --link --from=install-conda /opt/conda /opt/conda
-# COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
-# COPY --link --from=build-vision  /tmp/dist  /tmp/dist
-# COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
+# The `train` stage is the one actually used for training.
+# It is designed to be separate from the `build` stage,
+# with only the build artifacts (e.g., pip wheels) copied over.
+COPY --link --from=install-conda /opt/conda /opt/conda
+COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
+COPY --link --from=build-vision  /tmp/dist  /tmp/dist
+COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
 
-# ########################################################################
-# FROM ${BUILD_IMAGE} AS train-builds-exclude
-# # No compiled libraries copied over in exclude mode except Pillow-SIMD.
-# # Note that `fetch` stages are derived from the `install-conda` stage
-# # with no dependency on the `build-base` stage. This skips installation
-# # of any build-time dependencies, saving both time and space.
+########################################################################
+FROM ${BUILD_IMAGE} AS train-builds-exclude
+# No compiled libraries copied over in exclude mode except Pillow-SIMD.
+# Note that `fetch` stages are derived from the `install-conda` stage
+# with no dependency on the `build-base` stage. This skips installation
+# of any build-time dependencies, saving both time and space.
 
-# COPY --link --from=install-conda /opt/conda /opt/conda
-# COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
-# COPY --link --from=fetch-torch   /tmp/dist  /tmp/dist
-# COPY --link --from=fetch-vision  /tmp/dist  /tmp/dist
-# COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
+COPY --link --from=install-conda /opt/conda /opt/conda
+COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
+COPY --link --from=fetch-torch   /tmp/dist  /tmp/dist
+COPY --link --from=fetch-vision  /tmp/dist  /tmp/dist
+COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
 
-# ########################################################################
-# FROM train-builds-${BUILD_MODE} AS train-builds
-# # Gather Python packages built in previous stages and
-# # install using both conda and pip with a single file.
-# # Using a separate stage allows for build modularity
-# # and parallel installation with system packages.
+########################################################################
+FROM train-builds-${BUILD_MODE} AS train-builds
+# Gather Python packages built in previous stages and
+# install using both conda and pip with a single file.
+# Using a separate stage allows for build modularity
+# and parallel installation with system packages.
 
-# ARG INDEX_URL
-# ARG EXTRA_INDEX_URL
-# ARG TRUSTED_HOST
-# ARG PIP_CONFIG_FILE=/opt/conda/pip.conf
-# RUN {   echo "[global]"; \
-#         echo "index-url=${INDEX_URL}"; \
-#         echo "extra-index-url=${EXTRA_INDEX_URL}"; \
-#         echo "trusted-host=${TRUSTED_HOST}"; \
-#     } > ${PIP_CONFIG_FILE}
+ARG INDEX_URL
+ARG EXTRA_INDEX_URL
+ARG TRUSTED_HOST
+ARG PIP_CONFIG_FILE=/opt/conda/pip.conf
+RUN {   echo "[global]"; \
+        echo "index-url=${INDEX_URL}"; \
+        echo "extra-index-url=${EXTRA_INDEX_URL}"; \
+        echo "trusted-host=${TRUSTED_HOST}"; \
+    } > ${PIP_CONFIG_FILE}
 
-# # `CONDA_MANAGER` should be either `mamba` or `conda`.
-# # See the `install-conda` stage above for details.
-# ARG CONDA_MANAGER
-# ARG conda=/opt/conda/bin/${CONDA_MANAGER}
-# # Using `PIP_CACHE_DIR` and `CONDA_PKGS_DIRS`, both of which are
-# # native cache directory variables, to cache installations.
-# # Unclear which path `pip` inside a `conda` install uses for caching, however.
-# # https://pip.pypa.io/en/stable/topics/caching
-# # https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#specify-package-directories-pkgs-dirs
-# # Remove `__pycache__` directories to save a bit of space.
-# ARG PIP_CACHE_DIR=/root/.cache/pip
-# ARG CONDA_PKGS_DIRS=/opt/conda/pkgs
-# ARG CONDA_ENV_FILE=/tmp/train/environment.yaml
-# COPY --link ../reqs/train-environment.yaml ${CONDA_ENV_FILE}
-# RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
-#     --mount=type=cache,target=${CONDA_PKGS_DIRS},sharing=locked \
-#     find /tmp/dist -name '*.whl' | sed 's/^/      - /' >> ${CONDA_ENV_FILE} && \
-#     $conda env update --file ${CONDA_ENV_FILE}
+# `CONDA_MANAGER` should be either `mamba` or `conda`.
+# See the `install-conda` stage above for details.
+ARG CONDA_MANAGER
+ARG conda=/opt/conda/bin/${CONDA_MANAGER}
+# Using `PIP_CACHE_DIR` and `CONDA_PKGS_DIRS`, both of which are
+# native cache directory variables, to cache installations.
+# Unclear which path `pip` inside a `conda` install uses for caching, however.
+# https://pip.pypa.io/en/stable/topics/caching
+# https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#specify-package-directories-pkgs-dirs
+# Remove `__pycache__` directories to save a bit of space.
+ARG PIP_CACHE_DIR=/root/.cache/pip
+ARG CONDA_PKGS_DIRS=/opt/conda/pkgs
+ARG CONDA_ENV_FILE=/tmp/train/environment.yaml
+COPY --link ../reqs/train-environment.yaml ${CONDA_ENV_FILE}
+RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
+    --mount=type=cache,target=${CONDA_PKGS_DIRS},sharing=locked \
+    find /tmp/dist -name '*.whl' | sed 's/^/      - /' >> ${CONDA_ENV_FILE} && \
+    $conda env update --file ${CONDA_ENV_FILE}
 
-# RUN $conda clean -fya && find /opt/conda -type d -name '__pycache__' | xargs rm -rf
+RUN $conda clean -fya && find /opt/conda -type d -name '__pycache__' | xargs rm -rf
 
-# # Enable Intel MKL optimizations on AMD CPUs.
-# # https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
-# # RUN echo 'int mkl_serv_intel_cpu_true() {return 1;}' > /opt/conda/fakeintel.c && \
-# #     gcc -shared -fPIC -o /opt/conda/libfakeintel.so /opt/conda/fakeintel.c
+# Enable Intel MKL optimizations on AMD CPUs.
+# https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
+# RUN echo 'int mkl_serv_intel_cpu_true() {return 1;}' > /opt/conda/fakeintel.c && \
+#     gcc -shared -fPIC -o /opt/conda/libfakeintel.so /opt/conda/fakeintel.c
 
-# ########################################################################
-# FROM ${TRAIN_IMAGE} AS train-base
-# # Example Ubuntu training image on Intel x86_64 CPUs.
-# # Edit this section if necessary but use `docker-compose.yaml` if possible.
-# # Common configurations performed before creating a user should be placed here.
+########################################################################
+FROM ${TRAIN_IMAGE} AS train-base
+# Example Ubuntu training image on Intel x86_64 CPUs.
+# Edit this section if necessary but use `docker-compose.yaml` if possible.
+# Common configurations performed before creating a user should be placed here.
 
-# LABEL maintainer="veritas9872@gmail.com"
-# ENV LANG=C.UTF-8
-# ENV LC_ALL=C.UTF-8
-# ENV PYTHONIOENCODING=UTF-8
-# ARG PYTHONDONTWRITEBYTECODE=1
-# ARG PYTHONUNBUFFERED=1
+LABEL maintainer="veritas9872@gmail.com"
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PYTHONIOENCODING=UTF-8
+ARG PYTHONDONTWRITEBYTECODE=1
+ARG PYTHONUNBUFFERED=1
 
-# ARG TZ
-# ARG DEB_OLD
-# ARG DEB_NEW
-# # `tzdata` requires noninteractive mode.
-# ARG DEBIAN_FRONTEND=noninteractive
-# # Using `sed` and `xargs` to imitate the behavior of a requirements file.
-# # The `--mount=type=bind` temporarily mounts a directory from another stage.
-# # `apt` requirements are copied from the `train-stash` stage instead of from
-# # `train-builds` to allow parallel installation with `conda`.
-# # Intentionally ignoring the `apt` issue in Docker to reduce clutter and maybe space.
-# # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#example-cache-apt-packages
-# RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-#     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-#     --mount=type=bind,from=train-stash,source=/tmp/apt,target=/tmp/apt \
-#     ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone && \
-#     if [ ${DEB_NEW} ]; then sed -i "s%${DEB_OLD}%${DEB_NEW}%g" /etc/apt/sources.list; fi && \
-#     apt-get update && sed -e 's/#.*//g' -e 's/\r//g' /tmp/apt/requirements.txt | \
-#     xargs apt-get install -y --no-install-recommends && \
-#     rm -rf /var/lib/apt/lists/*
+ARG TZ
+ARG DEB_OLD
+ARG DEB_NEW
+# `tzdata` requires noninteractive mode.
+ARG DEBIAN_FRONTEND=noninteractive
+# Using `sed` and `xargs` to imitate the behavior of a requirements file.
+# The `--mount=type=bind` temporarily mounts a directory from another stage.
+# `apt` requirements are copied from the `train-stash` stage instead of from
+# `train-builds` to allow parallel installation with `conda`.
+# Intentionally ignoring the `apt` issue in Docker to reduce clutter and maybe space.
+# https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#example-cache-apt-packages
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=bind,from=train-stash,source=/tmp/apt,target=/tmp/apt \
+    ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone && \
+    if [ ${DEB_NEW} ]; then sed -i "s%${DEB_OLD}%${DEB_NEW}%g" /etc/apt/sources.list; fi && \
+    apt-get update && sed -e 's/#.*//g' -e 's/\r//g' /tmp/apt/requirements.txt | \
+    xargs apt-get install -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
 
-# ########################################################################
-# FROM train-base AS train-adduser-include
-# # This is the default training stage that most users will use most of the time.
-# # A new `sudo` user is created to help prevent file ownership issues and accidents.
-# ARG GID
-# ARG UID
-# ARG GRP
-# ARG USR
-# ARG PASSWD=ubuntu
-# # The `zsh` shell is used due to its convenience and popularity.
-# # Creating user with password-free sudo permissions.
-# # This may cause security issues. Use at your own risk.
-# RUN groupadd -f -g ${GID} ${GRP} && \
-#     useradd --shell $(which zsh) --create-home -u ${UID} -g ${GRP} \
-#         -p $(openssl passwd -1 ${PASSWD}) ${USR} && \
-#     echo "${USR} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+########################################################################
+FROM train-base AS train-adduser-include
+# This is the default training stage that most users will use most of the time.
+# A new `sudo` user is created to help prevent file ownership issues and accidents.
+ARG GID
+ARG UID
+ARG GRP
+ARG USR
+ARG PASSWD=ubuntu
+# The `zsh` shell is used due to its convenience and popularity.
+# Creating user with password-free sudo permissions.
+# This may cause security issues. Use at your own risk.
+RUN groupadd -f -g ${GID} ${GRP} && \
+    useradd --shell $(which zsh) --create-home -u ${UID} -g ${GRP} \
+        -p $(openssl passwd -1 ${PASSWD}) ${USR} && \
+    echo "${USR} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# # Get conda with the directory ownership given to the user.
-# COPY --link --from=train-builds --chown=${UID}:${GID} /opt/conda /opt/conda
+# Get conda with the directory ownership given to the user.
+COPY --link --from=train-builds --chown=${UID}:${GID} /opt/conda /opt/conda
 
-# ########################################################################
-# FROM train-base AS train-adduser-exclude
-# # This stage exists to create images for use in Kubernetes clusters, for
-# # uploading images to a container registry, or for use in rootless container environments,
-# # where having the image user set to `root` is most convenient.
-# # Singularity users may also find this stage useful.
-# # It is designed to be as close to the interactive development environment as
-# # possible, with the same `apt`, `conda`, and `pip` packages installed.
-# # Most users may safely ignore this stage except when publishing an image
-# # to a container repository for reproducibility.
-# # Note that this image does not require `zsh` but has `zsh` configs available.
+########################################################################
+FROM train-base AS train-adduser-exclude
+# This stage exists to create images for use in Kubernetes clusters, for
+# uploading images to a container registry, or for use in rootless container environments,
+# where having the image user set to `root` is most convenient.
+# Singularity users may also find this stage useful.
+# It is designed to be as close to the interactive development environment as
+# possible, with the same `apt`, `conda`, and `pip` packages installed.
+# Most users may safely ignore this stage except when publishing an image
+# to a container repository for reproducibility.
+# Note that this image does not require `zsh` but has `zsh` configs available.
 
-# COPY --link --from=train-builds /opt/conda /opt/conda
+COPY --link --from=train-builds /opt/conda /opt/conda
 
-# ########################################################################
-# FROM train-adduser-${ADD_USER} AS train
-# # Common configurations performed after `/opt/conda` installation
-# # should be placed here. Do not include any user-related options.
+########################################################################
+FROM train-adduser-${ADD_USER} AS train
+# Common configurations performed after `/opt/conda` installation
+# should be placed here. Do not include any user-related options.
 
-# # The `ZDOTDIR` variable specifies where to look for `zsh` configuration files.
-# # See the `zsh` manual for details. https://zsh-manual.netlify.app/files
-# ENV ZDOTDIR=/root
+# The `ZDOTDIR` variable specifies where to look for `zsh` configuration files.
+# See the `zsh` manual for details. https://zsh-manual.netlify.app/files
+ENV ZDOTDIR=/root
 
-# # Setting the prompt to `pure`, which is available on all terminals without additional settings.
-# # This is a personal preference and users may use any prompt that they wish (e.g., `oh-my-zsh`).
-# ARG PURE_PATH=${ZDOTDIR}/.zsh/pure
-# #ARG ZSHA_PATH=${ZDOTDIR}/.zsh/zsh-autosuggestions
-# ARG ZSHS_PATH=${ZDOTDIR}/.zsh/zsh-syntax-highlighting
-# COPY --link --from=train-builds /opt/zsh/pure ${PURE_PATH}
-# #COPY --link --from=train-builds /opt/zsh/zsh-autosuggestions ${ZSHA_PATH}
-# COPY --link --from=train-builds /opt/zsh/zsh-syntax-highlighting ${ZSHS_PATH}
+# Setting the prompt to `pure`, which is available on all terminals without additional settings.
+# This is a personal preference and users may use any prompt that they wish (e.g., `oh-my-zsh`).
+ARG PURE_PATH=${ZDOTDIR}/.zsh/pure
+#ARG ZSHA_PATH=${ZDOTDIR}/.zsh/zsh-autosuggestions
+ARG ZSHS_PATH=${ZDOTDIR}/.zsh/zsh-syntax-highlighting
+COPY --link --from=train-builds /opt/zsh/pure ${PURE_PATH}
+#COPY --link --from=train-builds /opt/zsh/zsh-autosuggestions ${ZSHA_PATH}
+COPY --link --from=train-builds /opt/zsh/zsh-syntax-highlighting ${ZSHS_PATH}
 
-# # Use Intel OpenMP with optimizations. See the documentation for details.
-# # https://intel.github.io/intel-extension-for-pytorch/cpu/latest/tutorials/performance_tuning/tuning_guide.html
-# # Intel OpenMP thread blocking time in ms.
-# ENV KMP_BLOCKTIME=0
-# # Configure CPU thread affinity.
-# # ENV KMP_AFFINITY="granularity=fine,compact,1,0"
-# ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so${LD_PRELOAD:+:${LD_PRELOAD}}
+# Use Intel OpenMP with optimizations. See the documentation for details.
+# https://intel.github.io/intel-extension-for-pytorch/cpu/latest/tutorials/performance_tuning/tuning_guide.html
+# Intel OpenMP thread blocking time in ms.
+ENV KMP_BLOCKTIME=0
+# Configure CPU thread affinity.
+# ENV KMP_AFFINITY="granularity=fine,compact,1,0"
+ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so${LD_PRELOAD:+:${LD_PRELOAD}}
 
-# # Enable Intel MKL optimizations on AMD CPUs. https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
-# ENV MKL_DEBUG_CPU_TYPE=5
-# ENV LD_PRELOAD=/opt/conda/libfakeintel.so${LD_PRELOAD:+:${LD_PRELOAD}}
+# Enable Intel MKL optimizations on AMD CPUs. https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
+ENV MKL_DEBUG_CPU_TYPE=5
+ENV LD_PRELOAD=/opt/conda/libfakeintel.so${LD_PRELOAD:+:${LD_PRELOAD}}
 
-# # Use Jemalloc for efficient memory management.
-# ENV LD_PRELOAD=/opt/conda/lib/libjemalloc.so${LD_PRELOAD:+:${LD_PRELOAD}}
-# ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000"
+# Use Jemalloc for efficient memory management.
+ENV LD_PRELOAD=/opt/conda/lib/libjemalloc.so${LD_PRELOAD:+:${LD_PRELOAD}}
+ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000"
 
-# ARG TMUX_HIST_LIMIT
-# RUN {   echo "fpath+=${PURE_PATH}"; \
-#         echo "autoload -Uz promptinit; promptinit"; \
-#         # Change the `tmux` path color to cyan since
-#         # the default blue is unreadable on a dark terminal.
-#         echo "zmodload zsh/nearcolor"; \
-#         echo "zstyle :prompt:pure:path color cyan"; \
-#         echo "prompt pure"; \
-#     } >> ${ZDOTDIR}/.zshrc && \
-#     # Add autosuggestions from terminal history. May be somewhat distracting.
-#     # echo "source ${ZSHA_PATH}/zsh-autosuggestions.zsh" >> ${ZDOTDIR}/.zshrc && \
-#     # Add custom `zsh` aliases and settings.
-#     {   echo "alias ll='ls -lh'"; \
-#         echo "alias wns='watch nvidia-smi'"; \
-#         echo "alias hist='history 1'"; \
-#     } >> ${ZDOTDIR}/.zshrc && \
-#     # Syntax highlighting must be activated at the end of the `.zshrc` file.
-#     echo "source ${ZSHS_PATH}/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR}/.zshrc && \
-#     # Configure `tmux` to use `zsh` as a non-login shell on startup.
-#     {   echo "set -g default-command $(which zsh)"; \
-#         echo "set -g history-limit ${TMUX_HIST_LIMIT}"; \
-#     } >> /etc/tmux.conf && \
-#     # For some reason, `tmux` does not read `/etc/tmux.conf`.
-#     echo 'cp /etc/tmux.conf ${HOME}/.tmux.conf' >> ${ZDOTDIR}/.zprofile && \
-#     # Change `ZDOTDIR` directory permissions to allow configuration sharing.
-#     chmod 755 ${ZDOTDIR} && \
-#     # Clear out `/tmp` and restore its default permissions.
-#     rm -rf /tmp && mkdir /tmp && chmod 1777 /tmp && \
-#     ldconfig  # Update dynamic link cache.
+ARG TMUX_HIST_LIMIT
+RUN {   echo "fpath+=${PURE_PATH}"; \
+        echo "autoload -Uz promptinit; promptinit"; \
+        # Change the `tmux` path color to cyan since
+        # the default blue is unreadable on a dark terminal.
+        echo "zmodload zsh/nearcolor"; \
+        echo "zstyle :prompt:pure:path color cyan"; \
+        echo "prompt pure"; \
+    } >> ${ZDOTDIR}/.zshrc && \
+    # Add autosuggestions from terminal history. May be somewhat distracting.
+    # echo "source ${ZSHA_PATH}/zsh-autosuggestions.zsh" >> ${ZDOTDIR}/.zshrc && \
+    # Add custom `zsh` aliases and settings.
+    {   echo "alias ll='ls -lh'"; \
+        echo "alias wns='watch nvidia-smi'"; \
+        echo "alias hist='history 1'"; \
+    } >> ${ZDOTDIR}/.zshrc && \
+    # Syntax highlighting must be activated at the end of the `.zshrc` file.
+    echo "source ${ZSHS_PATH}/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR}/.zshrc && \
+    # Configure `tmux` to use `zsh` as a non-login shell on startup.
+    {   echo "set -g default-command $(which zsh)"; \
+        echo "set -g history-limit ${TMUX_HIST_LIMIT}"; \
+    } >> /etc/tmux.conf && \
+    # For some reason, `tmux` does not read `/etc/tmux.conf`.
+    echo 'cp /etc/tmux.conf ${HOME}/.tmux.conf' >> ${ZDOTDIR}/.zprofile && \
+    # Change `ZDOTDIR` directory permissions to allow configuration sharing.
+    chmod 755 ${ZDOTDIR} && \
+    # Clear out `/tmp` and restore its default permissions.
+    rm -rf /tmp && mkdir /tmp && chmod 1777 /tmp && \
+    ldconfig  # Update dynamic link cache.
 
-# ENV PATH=/opt/conda/bin:${PATH}
-# # `PROJECT_ROOT` is where the project code will reside.
-# ARG PROJECT_ROOT=/opt/project
-# ENV PYTHONPATH=${PROJECT_ROOT}${PYTHONPATH:+:${PYTHONPATH}}
-# WORKDIR ${PROJECT_ROOT}
-# CMD ["/usr/bin/zsh"]
+ENV PATH=/opt/conda/bin:${PATH}
+# `PROJECT_ROOT` is where the project code will reside.
+ARG PROJECT_ROOT=/opt/project
+ENV PYTHONPATH=${PROJECT_ROOT}${PYTHONPATH:+:${PYTHONPATH}}
+WORKDIR ${PROJECT_ROOT}
+CMD ["/usr/bin/zsh"]

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -221,7 +221,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
-RUN python -c "import platform"
+RUN python -c "import platform; print( platform.machine())" && exit 1
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -221,6 +221,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
+RUN pip list; exit 1
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -219,6 +219,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # Install PyTorch for subsidiary libraries (e.g., TorchVision).
 # " we strongly recommend enabling linker script optimization for ARM + CUDA"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
+RUN which ld
 ARG USE_PRIORITIZED_TEXT_FOR_LD=1
 RUN --mount=type=cache,target=/opt/ccache \
     python setup.py bdist_wheel -d /tmp/dist && \

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -226,365 +226,366 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
 
 # cat setup.py && \
-RUN --mount=type=cache,target=/opt/ccache \
-   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist; exit 1
+# RUN --mount=type=cache,target=/opt/ccache \
+#    CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist; exit 1
 
+ENTRYPOINT [ "/bin/bash" ]
 
     
-ARG VERBOSE=1
-ARG MAX_JOBS=1  
-RUN python setup.py install
-RUN pip list; exit 1
+# ARG VERBOSE=1
+# ARG MAX_JOBS=1  
+# RUN python setup.py install
+# RUN pip list; exit 1
 
-###### Additional information for custom builds. ######
+# ###### Additional information for custom builds. ######
 
-# Use the following to build with custom CMake settings.
-#RUN --mount=type=cache,target=/opt/ccache \
-#    python setup.py build --cmake-only && \
-#    ccmake build  # or cmake-gui build
+# # Use the following to build with custom CMake settings.
+# #RUN --mount=type=cache,target=/opt/ccache \
+# #    python setup.py build --cmake-only && \
+# #    ccmake build  # or cmake-gui build
 
-# Visit the Setuptools documentation for more `setup.py` options.
-# https://setuptools.pypa.io/en/latest
+# # Visit the Setuptools documentation for more `setup.py` options.
+# # https://setuptools.pypa.io/en/latest
 
-# C++ developers using Libtorch can find the library in
-# `torch/lib/tmp_install/lib/libtorch.so`.
+# # C++ developers using Libtorch can find the library in
+# # `torch/lib/tmp_install/lib/libtorch.so`.
 
-# The default configuration removes all files except requirements files from the Docker context.
-# To `COPY` your source files during the build, please edit the `.dockerignore` file.
+# # The default configuration removes all files except requirements files from the Docker context.
+# # To `COPY` your source files during the build, please edit the `.dockerignore` file.
 
-# A detailed (if out of date) explanation of the buildsystem can be found below.
-# https://pytorch.org/blog/a-tour-of-pytorch-internals-2
-# The following repository may also be helpful for available options and possible issues.
-# https://github.com/mratsim/Arch-Data-Science/blob/master/frameworks/python-pytorch-magma-mkldnn-cudnn-git/PKGBUILD
+# # A detailed (if out of date) explanation of the buildsystem can be found below.
+# # https://pytorch.org/blog/a-tour-of-pytorch-internals-2
+# # The following repository may also be helpful for available options and possible issues.
+# # https://github.com/mratsim/Arch-Data-Science/blob/master/frameworks/python-pytorch-magma-mkldnn-cudnn-git/PKGBUILD
 
-# Manually specify conda package versions if older PyTorch versions will not build.
-# PyYAML, MKL-DNN, and Setuptools are known culprits.
+# # Manually specify conda package versions if older PyTorch versions will not build.
+# # PyYAML, MKL-DNN, and Setuptools are known culprits.
 
-# Run the command below before building to enable ROCM builds.
-# RUN python tools/amd_build/build_amd.py
-# PyTorch builds with ROCM have not been tested.
-# Note that PyTorch for ROCM is still in beta and the ROCM build API may change.
+# # Run the command below before building to enable ROCM builds.
+# # RUN python tools/amd_build/build_amd.py
+# # PyTorch builds with ROCM have not been tested.
+# # Note that PyTorch for ROCM is still in beta and the ROCM build API may change.
 
-# To build for Jetson Nano devices, see the link below for the necessary modifications.
-# https://forums.developer.nvidia.com/t/pytorch-for-jetson-version-1-10-now-available/72048
+# # To build for Jetson Nano devices, see the link below for the necessary modifications.
+# # https://forums.developer.nvidia.com/t/pytorch-for-jetson-version-1-10-now-available/72048
 
-########################################################################
-FROM install-conda AS build-pillow
-# This stage is derived from `install-conda` instead of `build-base`
-# as it is very lightweight and does not require many dependencies.
-RUN $conda install -y libjpeg-turbo zlib && $conda clean -fya
+# ########################################################################
+# FROM install-conda AS build-pillow
+# # This stage is derived from `install-conda` instead of `build-base`
+# # as it is very lightweight and does not require many dependencies.
+# RUN $conda install -y libjpeg-turbo zlib && $conda clean -fya
 
-# Specify the `Pillow-SIMD` version if necessary. The variable is not used yet.
-# Set as `PILLOW_SIMD_VERSION="==VERSION_NUMBER"` for use in the current setup.
-ARG PILLOW_SIMD_VERSION
-# The condition ensures that AVX2 instructions are built only if available.
-# May cause issues if the image is used on a machine with a different SIMD ISA.
-#RUN if [ ! "$(lscpu | grep -q avx2)" ]; then CC="cc -mavx2"; fi && \
-#    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
-#        Pillow-SIMD${PILLOW_SIMD_VERSION}
+# # Specify the `Pillow-SIMD` version if necessary. The variable is not used yet.
+# # Set as `PILLOW_SIMD_VERSION="==VERSION_NUMBER"` for use in the current setup.
+# ARG PILLOW_SIMD_VERSION
+# # The condition ensures that AVX2 instructions are built only if available.
+# # May cause issues if the image is used on a machine with a different SIMD ISA.
+# #RUN if [ ! "$(lscpu | grep -q avx2)" ]; then CC="cc -mavx2"; fi && \
+# #    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
+# #        Pillow-SIMD${PILLOW_SIMD_VERSION}
 
-## Use Pillow-SIMD if available and not on aarch64
-ARG USE_PILLOW_SIMD=false
-RUN if [ "$USE_PILLOW_SIMD" = "false" ] || [ "$(uname -m)" = "aarch64" ]; then \
-        PILLOW_PACKAGE="Pillow"; \
-    else \
-        PILLOW_PACKAGE="Pillow-SIMD"; \
-    fi && \
-    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
-        ${PILLOW_PACKAGE}${PILLOW_SIMD_VERSION}
-########################################################################
-FROM ${GIT_IMAGE} AS clone-vision
+# ## Use Pillow-SIMD if available and not on aarch64
+# ARG USE_PILLOW_SIMD=false
+# RUN if [ "$USE_PILLOW_SIMD" = "false" ] || [ "$(uname -m)" = "aarch64" ]; then \
+#         PILLOW_PACKAGE="Pillow"; \
+#     else \
+#         PILLOW_PACKAGE="Pillow-SIMD"; \
+#     fi && \
+#     python -m pip wheel --no-deps --wheel-dir /tmp/dist \
+#         ${PILLOW_PACKAGE}${PILLOW_SIMD_VERSION}
+# ########################################################################
+# FROM ${GIT_IMAGE} AS clone-vision
 
-ARG TORCHVISION_VERSION_TAG
-ARG VISION_URL=https://github.com/pytorch/vision.git
-RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
-        --single-branch --shallow-submodules --recurse-submodules \
-        --branch ${TORCHVISION_VERSION_TAG} ${VISION_URL} /opt/vision
+# ARG TORCHVISION_VERSION_TAG
+# ARG VISION_URL=https://github.com/pytorch/vision.git
+# RUN git clone --jobs $(( 8 < $(nproc) ? 8: $(nproc) )) --depth 1 \
+#         --single-branch --shallow-submodules --recurse-submodules \
+#         --branch ${TORCHVISION_VERSION_TAG} ${VISION_URL} /opt/vision
 
-########################################################################
-FROM build-torch AS build-vision
+# ########################################################################
+# FROM build-torch AS build-vision
 
-WORKDIR /opt/vision
-COPY --link --from=clone-vision /opt/vision /opt/vision
+# WORKDIR /opt/vision
+# COPY --link --from=clone-vision /opt/vision /opt/vision
 
-RUN pip list; exit 1
+# RUN pip list; exit 1
 
-# Install Pillow-SIMD before TorchVision build and add it to `/tmp/dist`.
-# Pillow will be uninstalled if it is present.
-RUN --mount=type=bind,from=build-pillow,source=/tmp/dist,target=/tmp/dist \
-    python -m pip install --no-deps /tmp/dist/*
-# python -m pip uninstall -y pillow && \
+# # Install Pillow-SIMD before TorchVision build and add it to `/tmp/dist`.
+# # Pillow will be uninstalled if it is present.
+# RUN --mount=type=bind,from=build-pillow,source=/tmp/dist,target=/tmp/dist \
+#     python -m pip install --no-deps /tmp/dist/*
+# # python -m pip uninstall -y pillow && \
 
-ARG USE_CUDA
-ARG USE_PRECOMPILED_HEADERS
-ARG FORCE_CUDA=${USE_CUDA}
-ARG TORCH_CUDA_ARCH_LIST
-RUN --mount=type=cache,target=/opt/ccache \
-    pwd; cat setup.py && \
-    python setup.py bdist_wheel -d /tmp/dist
+# ARG USE_CUDA
+# ARG USE_PRECOMPILED_HEADERS
+# ARG FORCE_CUDA=${USE_CUDA}
+# ARG TORCH_CUDA_ARCH_LIST
+# RUN --mount=type=cache,target=/opt/ccache \
+#     pwd; cat setup.py && \
+#     python setup.py bdist_wheel -d /tmp/dist
 
-########################################################################
-FROM ${GIT_IMAGE} AS fetch-pure
+# ########################################################################
+# FROM ${GIT_IMAGE} AS fetch-pure
 
-# Z-Shell related libraries.
-ARG PURE_URL=https://github.com/sindresorhus/pure.git
-ARG ZSHA_URL=https://github.com/zsh-users/zsh-autosuggestions
-ARG ZSHS_URL=https://github.com/zsh-users/zsh-syntax-highlighting.git
+# # Z-Shell related libraries.
+# ARG PURE_URL=https://github.com/sindresorhus/pure.git
+# ARG ZSHA_URL=https://github.com/zsh-users/zsh-autosuggestions
+# ARG ZSHS_URL=https://github.com/zsh-users/zsh-syntax-highlighting.git
 
-RUN git clone --depth 1 ${PURE_URL} /opt/zsh/pure
-RUN git clone --depth 1 ${ZSHA_URL} /opt/zsh/zsh-autosuggestions
-RUN git clone --depth 1 ${ZSHS_URL} /opt/zsh/zsh-syntax-highlighting
+# RUN git clone --depth 1 ${PURE_URL} /opt/zsh/pure
+# RUN git clone --depth 1 ${ZSHA_URL} /opt/zsh/zsh-autosuggestions
+# RUN git clone --depth 1 ${ZSHS_URL} /opt/zsh/zsh-syntax-highlighting
 
-########################################################################
-FROM install-conda AS fetch-torch
+# ########################################################################
+# FROM install-conda AS fetch-torch
 
-# For users who wish to download wheels instead of building them.
-ARG PYTORCH_INDEX_URL
-ARG PYTORCH_FETCH_NIGHTLY
-ARG PYTORCH_VERSION
-RUN if [ -z ${PYTORCH_FETCH_NIGHTLY} ]; then \
-        python -m pip wheel \
-            --no-deps --wheel-dir /tmp/dist \
-            --index-url ${PYTORCH_INDEX_URL} \
-            torch==${PYTORCH_VERSION}; \
-    else \
-        python -m pip wheel --pre \
-            --no-deps --wheel-dir /tmp/dist \
-            --index-url ${PYTORCH_INDEX_URL} \
-            torch; \
-    fi
+# # For users who wish to download wheels instead of building them.
+# ARG PYTORCH_INDEX_URL
+# ARG PYTORCH_FETCH_NIGHTLY
+# ARG PYTORCH_VERSION
+# RUN if [ -z ${PYTORCH_FETCH_NIGHTLY} ]; then \
+#         python -m pip wheel \
+#             --no-deps --wheel-dir /tmp/dist \
+#             --index-url ${PYTORCH_INDEX_URL} \
+#             torch==${PYTORCH_VERSION}; \
+#     else \
+#         python -m pip wheel --pre \
+#             --no-deps --wheel-dir /tmp/dist \
+#             --index-url ${PYTORCH_INDEX_URL} \
+#             torch; \
+#     fi
 
-########################################################################
-FROM install-conda AS fetch-vision
+# ########################################################################
+# FROM install-conda AS fetch-vision
 
-ARG PYTORCH_INDEX_URL
-ARG PYTORCH_FETCH_NIGHTLY
-ARG TORCHVISION_VERSION
-RUN if [ -z ${PYTORCH_FETCH_NIGHTLY} ]; then \
-        python -m pip wheel \
-            --no-deps --wheel-dir /tmp/dist \
-            --index-url ${PYTORCH_INDEX_URL} \
-            torchvision==${TORCHVISION_VERSION}; \
-    else \
-        python -m pip wheel --pre \
-            --no-deps --wheel-dir /tmp/dist \
-            --index-url ${PYTORCH_INDEX_URL} \
-            torchvision; \
-    fi
+# ARG PYTORCH_INDEX_URL
+# ARG PYTORCH_FETCH_NIGHTLY
+# ARG TORCHVISION_VERSION
+# RUN if [ -z ${PYTORCH_FETCH_NIGHTLY} ]; then \
+#         python -m pip wheel \
+#             --no-deps --wheel-dir /tmp/dist \
+#             --index-url ${PYTORCH_INDEX_URL} \
+#             torchvision==${TORCHVISION_VERSION}; \
+#     else \
+#         python -m pip wheel --pre \
+#             --no-deps --wheel-dir /tmp/dist \
+#             --index-url ${PYTORCH_INDEX_URL} \
+#             torchvision; \
+#     fi
 
-########################################################################
-FROM ${BUILD_IMAGE} AS train-stash
+# ########################################################################
+# FROM ${BUILD_IMAGE} AS train-stash
 
-# This stage prevents direct contact between the `train` stage and external files.
-# Other files such as `.deb` package files may also be stashed here.
-COPY --link ../reqs/train-apt.requirements.txt /tmp/apt/requirements.txt
+# # This stage prevents direct contact between the `train` stage and external files.
+# # Other files such as `.deb` package files may also be stashed here.
+# COPY --link ../reqs/train-apt.requirements.txt /tmp/apt/requirements.txt
 
-########################################################################
-FROM ${BUILD_IMAGE} AS train-builds-include
-# A convenience stage to gather build artifacts (wheels, etc.) for the train stage.
-# If other source builds are included later on, gather them here as well.
-# All pip wheels are located in `/tmp/dist`.
-# Using an image other than `BUILD_IMAGE` may contaminate
-# `/opt/conda` and other key directories.
+# ########################################################################
+# FROM ${BUILD_IMAGE} AS train-builds-include
+# # A convenience stage to gather build artifacts (wheels, etc.) for the train stage.
+# # If other source builds are included later on, gather them here as well.
+# # All pip wheels are located in `/tmp/dist`.
+# # Using an image other than `BUILD_IMAGE` may contaminate
+# # `/opt/conda` and other key directories.
 
-# The `train` stage is the one actually used for training.
-# It is designed to be separate from the `build` stage,
-# with only the build artifacts (e.g., pip wheels) copied over.
-COPY --link --from=install-conda /opt/conda /opt/conda
-COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
-COPY --link --from=build-vision  /tmp/dist  /tmp/dist
-COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
+# # The `train` stage is the one actually used for training.
+# # It is designed to be separate from the `build` stage,
+# # with only the build artifacts (e.g., pip wheels) copied over.
+# COPY --link --from=install-conda /opt/conda /opt/conda
+# COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
+# COPY --link --from=build-vision  /tmp/dist  /tmp/dist
+# COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
 
-########################################################################
-FROM ${BUILD_IMAGE} AS train-builds-exclude
-# No compiled libraries copied over in exclude mode except Pillow-SIMD.
-# Note that `fetch` stages are derived from the `install-conda` stage
-# with no dependency on the `build-base` stage. This skips installation
-# of any build-time dependencies, saving both time and space.
+# ########################################################################
+# FROM ${BUILD_IMAGE} AS train-builds-exclude
+# # No compiled libraries copied over in exclude mode except Pillow-SIMD.
+# # Note that `fetch` stages are derived from the `install-conda` stage
+# # with no dependency on the `build-base` stage. This skips installation
+# # of any build-time dependencies, saving both time and space.
 
-COPY --link --from=install-conda /opt/conda /opt/conda
-COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
-COPY --link --from=fetch-torch   /tmp/dist  /tmp/dist
-COPY --link --from=fetch-vision  /tmp/dist  /tmp/dist
-COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
+# COPY --link --from=install-conda /opt/conda /opt/conda
+# COPY --link --from=build-pillow  /tmp/dist  /tmp/dist
+# COPY --link --from=fetch-torch   /tmp/dist  /tmp/dist
+# COPY --link --from=fetch-vision  /tmp/dist  /tmp/dist
+# COPY --link --from=fetch-pure    /opt/zsh   /opt/zsh
 
-########################################################################
-FROM train-builds-${BUILD_MODE} AS train-builds
-# Gather Python packages built in previous stages and
-# install using both conda and pip with a single file.
-# Using a separate stage allows for build modularity
-# and parallel installation with system packages.
+# ########################################################################
+# FROM train-builds-${BUILD_MODE} AS train-builds
+# # Gather Python packages built in previous stages and
+# # install using both conda and pip with a single file.
+# # Using a separate stage allows for build modularity
+# # and parallel installation with system packages.
 
-ARG INDEX_URL
-ARG EXTRA_INDEX_URL
-ARG TRUSTED_HOST
-ARG PIP_CONFIG_FILE=/opt/conda/pip.conf
-RUN {   echo "[global]"; \
-        echo "index-url=${INDEX_URL}"; \
-        echo "extra-index-url=${EXTRA_INDEX_URL}"; \
-        echo "trusted-host=${TRUSTED_HOST}"; \
-    } > ${PIP_CONFIG_FILE}
+# ARG INDEX_URL
+# ARG EXTRA_INDEX_URL
+# ARG TRUSTED_HOST
+# ARG PIP_CONFIG_FILE=/opt/conda/pip.conf
+# RUN {   echo "[global]"; \
+#         echo "index-url=${INDEX_URL}"; \
+#         echo "extra-index-url=${EXTRA_INDEX_URL}"; \
+#         echo "trusted-host=${TRUSTED_HOST}"; \
+#     } > ${PIP_CONFIG_FILE}
 
-# `CONDA_MANAGER` should be either `mamba` or `conda`.
-# See the `install-conda` stage above for details.
-ARG CONDA_MANAGER
-ARG conda=/opt/conda/bin/${CONDA_MANAGER}
-# Using `PIP_CACHE_DIR` and `CONDA_PKGS_DIRS`, both of which are
-# native cache directory variables, to cache installations.
-# Unclear which path `pip` inside a `conda` install uses for caching, however.
-# https://pip.pypa.io/en/stable/topics/caching
-# https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#specify-package-directories-pkgs-dirs
-# Remove `__pycache__` directories to save a bit of space.
-ARG PIP_CACHE_DIR=/root/.cache/pip
-ARG CONDA_PKGS_DIRS=/opt/conda/pkgs
-ARG CONDA_ENV_FILE=/tmp/train/environment.yaml
-COPY --link ../reqs/train-environment.yaml ${CONDA_ENV_FILE}
-RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
-    --mount=type=cache,target=${CONDA_PKGS_DIRS},sharing=locked \
-    find /tmp/dist -name '*.whl' | sed 's/^/      - /' >> ${CONDA_ENV_FILE} && \
-    $conda env update --file ${CONDA_ENV_FILE}
+# # `CONDA_MANAGER` should be either `mamba` or `conda`.
+# # See the `install-conda` stage above for details.
+# ARG CONDA_MANAGER
+# ARG conda=/opt/conda/bin/${CONDA_MANAGER}
+# # Using `PIP_CACHE_DIR` and `CONDA_PKGS_DIRS`, both of which are
+# # native cache directory variables, to cache installations.
+# # Unclear which path `pip` inside a `conda` install uses for caching, however.
+# # https://pip.pypa.io/en/stable/topics/caching
+# # https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#specify-package-directories-pkgs-dirs
+# # Remove `__pycache__` directories to save a bit of space.
+# ARG PIP_CACHE_DIR=/root/.cache/pip
+# ARG CONDA_PKGS_DIRS=/opt/conda/pkgs
+# ARG CONDA_ENV_FILE=/tmp/train/environment.yaml
+# COPY --link ../reqs/train-environment.yaml ${CONDA_ENV_FILE}
+# RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
+#     --mount=type=cache,target=${CONDA_PKGS_DIRS},sharing=locked \
+#     find /tmp/dist -name '*.whl' | sed 's/^/      - /' >> ${CONDA_ENV_FILE} && \
+#     $conda env update --file ${CONDA_ENV_FILE}
 
-RUN $conda clean -fya && find /opt/conda -type d -name '__pycache__' | xargs rm -rf
+# RUN $conda clean -fya && find /opt/conda -type d -name '__pycache__' | xargs rm -rf
 
-# Enable Intel MKL optimizations on AMD CPUs.
-# https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
-# RUN echo 'int mkl_serv_intel_cpu_true() {return 1;}' > /opt/conda/fakeintel.c && \
-#     gcc -shared -fPIC -o /opt/conda/libfakeintel.so /opt/conda/fakeintel.c
+# # Enable Intel MKL optimizations on AMD CPUs.
+# # https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
+# # RUN echo 'int mkl_serv_intel_cpu_true() {return 1;}' > /opt/conda/fakeintel.c && \
+# #     gcc -shared -fPIC -o /opt/conda/libfakeintel.so /opt/conda/fakeintel.c
 
-########################################################################
-FROM ${TRAIN_IMAGE} AS train-base
-# Example Ubuntu training image on Intel x86_64 CPUs.
-# Edit this section if necessary but use `docker-compose.yaml` if possible.
-# Common configurations performed before creating a user should be placed here.
+# ########################################################################
+# FROM ${TRAIN_IMAGE} AS train-base
+# # Example Ubuntu training image on Intel x86_64 CPUs.
+# # Edit this section if necessary but use `docker-compose.yaml` if possible.
+# # Common configurations performed before creating a user should be placed here.
 
-LABEL maintainer="veritas9872@gmail.com"
-ENV LANG=C.UTF-8
-ENV LC_ALL=C.UTF-8
-ENV PYTHONIOENCODING=UTF-8
-ARG PYTHONDONTWRITEBYTECODE=1
-ARG PYTHONUNBUFFERED=1
+# LABEL maintainer="veritas9872@gmail.com"
+# ENV LANG=C.UTF-8
+# ENV LC_ALL=C.UTF-8
+# ENV PYTHONIOENCODING=UTF-8
+# ARG PYTHONDONTWRITEBYTECODE=1
+# ARG PYTHONUNBUFFERED=1
 
-ARG TZ
-ARG DEB_OLD
-ARG DEB_NEW
-# `tzdata` requires noninteractive mode.
-ARG DEBIAN_FRONTEND=noninteractive
-# Using `sed` and `xargs` to imitate the behavior of a requirements file.
-# The `--mount=type=bind` temporarily mounts a directory from another stage.
-# `apt` requirements are copied from the `train-stash` stage instead of from
-# `train-builds` to allow parallel installation with `conda`.
-# Intentionally ignoring the `apt` issue in Docker to reduce clutter and maybe space.
-# https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#example-cache-apt-packages
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    --mount=type=bind,from=train-stash,source=/tmp/apt,target=/tmp/apt \
-    ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone && \
-    if [ ${DEB_NEW} ]; then sed -i "s%${DEB_OLD}%${DEB_NEW}%g" /etc/apt/sources.list; fi && \
-    apt-get update && sed -e 's/#.*//g' -e 's/\r//g' /tmp/apt/requirements.txt | \
-    xargs apt-get install -y --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
+# ARG TZ
+# ARG DEB_OLD
+# ARG DEB_NEW
+# # `tzdata` requires noninteractive mode.
+# ARG DEBIAN_FRONTEND=noninteractive
+# # Using `sed` and `xargs` to imitate the behavior of a requirements file.
+# # The `--mount=type=bind` temporarily mounts a directory from another stage.
+# # `apt` requirements are copied from the `train-stash` stage instead of from
+# # `train-builds` to allow parallel installation with `conda`.
+# # Intentionally ignoring the `apt` issue in Docker to reduce clutter and maybe space.
+# # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#example-cache-apt-packages
+# RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+#     --mount=type=cache,target=/var/lib/apt,sharing=locked \
+#     --mount=type=bind,from=train-stash,source=/tmp/apt,target=/tmp/apt \
+#     ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone && \
+#     if [ ${DEB_NEW} ]; then sed -i "s%${DEB_OLD}%${DEB_NEW}%g" /etc/apt/sources.list; fi && \
+#     apt-get update && sed -e 's/#.*//g' -e 's/\r//g' /tmp/apt/requirements.txt | \
+#     xargs apt-get install -y --no-install-recommends && \
+#     rm -rf /var/lib/apt/lists/*
 
-########################################################################
-FROM train-base AS train-adduser-include
-# This is the default training stage that most users will use most of the time.
-# A new `sudo` user is created to help prevent file ownership issues and accidents.
-ARG GID
-ARG UID
-ARG GRP
-ARG USR
-ARG PASSWD=ubuntu
-# The `zsh` shell is used due to its convenience and popularity.
-# Creating user with password-free sudo permissions.
-# This may cause security issues. Use at your own risk.
-RUN groupadd -f -g ${GID} ${GRP} && \
-    useradd --shell $(which zsh) --create-home -u ${UID} -g ${GRP} \
-        -p $(openssl passwd -1 ${PASSWD}) ${USR} && \
-    echo "${USR} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+# ########################################################################
+# FROM train-base AS train-adduser-include
+# # This is the default training stage that most users will use most of the time.
+# # A new `sudo` user is created to help prevent file ownership issues and accidents.
+# ARG GID
+# ARG UID
+# ARG GRP
+# ARG USR
+# ARG PASSWD=ubuntu
+# # The `zsh` shell is used due to its convenience and popularity.
+# # Creating user with password-free sudo permissions.
+# # This may cause security issues. Use at your own risk.
+# RUN groupadd -f -g ${GID} ${GRP} && \
+#     useradd --shell $(which zsh) --create-home -u ${UID} -g ${GRP} \
+#         -p $(openssl passwd -1 ${PASSWD}) ${USR} && \
+#     echo "${USR} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Get conda with the directory ownership given to the user.
-COPY --link --from=train-builds --chown=${UID}:${GID} /opt/conda /opt/conda
+# # Get conda with the directory ownership given to the user.
+# COPY --link --from=train-builds --chown=${UID}:${GID} /opt/conda /opt/conda
 
-########################################################################
-FROM train-base AS train-adduser-exclude
-# This stage exists to create images for use in Kubernetes clusters, for
-# uploading images to a container registry, or for use in rootless container environments,
-# where having the image user set to `root` is most convenient.
-# Singularity users may also find this stage useful.
-# It is designed to be as close to the interactive development environment as
-# possible, with the same `apt`, `conda`, and `pip` packages installed.
-# Most users may safely ignore this stage except when publishing an image
-# to a container repository for reproducibility.
-# Note that this image does not require `zsh` but has `zsh` configs available.
+# ########################################################################
+# FROM train-base AS train-adduser-exclude
+# # This stage exists to create images for use in Kubernetes clusters, for
+# # uploading images to a container registry, or for use in rootless container environments,
+# # where having the image user set to `root` is most convenient.
+# # Singularity users may also find this stage useful.
+# # It is designed to be as close to the interactive development environment as
+# # possible, with the same `apt`, `conda`, and `pip` packages installed.
+# # Most users may safely ignore this stage except when publishing an image
+# # to a container repository for reproducibility.
+# # Note that this image does not require `zsh` but has `zsh` configs available.
 
-COPY --link --from=train-builds /opt/conda /opt/conda
+# COPY --link --from=train-builds /opt/conda /opt/conda
 
-########################################################################
-FROM train-adduser-${ADD_USER} AS train
-# Common configurations performed after `/opt/conda` installation
-# should be placed here. Do not include any user-related options.
+# ########################################################################
+# FROM train-adduser-${ADD_USER} AS train
+# # Common configurations performed after `/opt/conda` installation
+# # should be placed here. Do not include any user-related options.
 
-# The `ZDOTDIR` variable specifies where to look for `zsh` configuration files.
-# See the `zsh` manual for details. https://zsh-manual.netlify.app/files
-ENV ZDOTDIR=/root
+# # The `ZDOTDIR` variable specifies where to look for `zsh` configuration files.
+# # See the `zsh` manual for details. https://zsh-manual.netlify.app/files
+# ENV ZDOTDIR=/root
 
-# Setting the prompt to `pure`, which is available on all terminals without additional settings.
-# This is a personal preference and users may use any prompt that they wish (e.g., `oh-my-zsh`).
-ARG PURE_PATH=${ZDOTDIR}/.zsh/pure
-#ARG ZSHA_PATH=${ZDOTDIR}/.zsh/zsh-autosuggestions
-ARG ZSHS_PATH=${ZDOTDIR}/.zsh/zsh-syntax-highlighting
-COPY --link --from=train-builds /opt/zsh/pure ${PURE_PATH}
-#COPY --link --from=train-builds /opt/zsh/zsh-autosuggestions ${ZSHA_PATH}
-COPY --link --from=train-builds /opt/zsh/zsh-syntax-highlighting ${ZSHS_PATH}
+# # Setting the prompt to `pure`, which is available on all terminals without additional settings.
+# # This is a personal preference and users may use any prompt that they wish (e.g., `oh-my-zsh`).
+# ARG PURE_PATH=${ZDOTDIR}/.zsh/pure
+# #ARG ZSHA_PATH=${ZDOTDIR}/.zsh/zsh-autosuggestions
+# ARG ZSHS_PATH=${ZDOTDIR}/.zsh/zsh-syntax-highlighting
+# COPY --link --from=train-builds /opt/zsh/pure ${PURE_PATH}
+# #COPY --link --from=train-builds /opt/zsh/zsh-autosuggestions ${ZSHA_PATH}
+# COPY --link --from=train-builds /opt/zsh/zsh-syntax-highlighting ${ZSHS_PATH}
 
-# Use Intel OpenMP with optimizations. See the documentation for details.
-# https://intel.github.io/intel-extension-for-pytorch/cpu/latest/tutorials/performance_tuning/tuning_guide.html
-# Intel OpenMP thread blocking time in ms.
-ENV KMP_BLOCKTIME=0
-# Configure CPU thread affinity.
-# ENV KMP_AFFINITY="granularity=fine,compact,1,0"
-ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so${LD_PRELOAD:+:${LD_PRELOAD}}
+# # Use Intel OpenMP with optimizations. See the documentation for details.
+# # https://intel.github.io/intel-extension-for-pytorch/cpu/latest/tutorials/performance_tuning/tuning_guide.html
+# # Intel OpenMP thread blocking time in ms.
+# ENV KMP_BLOCKTIME=0
+# # Configure CPU thread affinity.
+# # ENV KMP_AFFINITY="granularity=fine,compact,1,0"
+# ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so${LD_PRELOAD:+:${LD_PRELOAD}}
 
-# Enable Intel MKL optimizations on AMD CPUs. https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
-ENV MKL_DEBUG_CPU_TYPE=5
-ENV LD_PRELOAD=/opt/conda/libfakeintel.so${LD_PRELOAD:+:${LD_PRELOAD}}
+# # Enable Intel MKL optimizations on AMD CPUs. https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
+# ENV MKL_DEBUG_CPU_TYPE=5
+# ENV LD_PRELOAD=/opt/conda/libfakeintel.so${LD_PRELOAD:+:${LD_PRELOAD}}
 
-# Use Jemalloc for efficient memory management.
-ENV LD_PRELOAD=/opt/conda/lib/libjemalloc.so${LD_PRELOAD:+:${LD_PRELOAD}}
-ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000"
+# # Use Jemalloc for efficient memory management.
+# ENV LD_PRELOAD=/opt/conda/lib/libjemalloc.so${LD_PRELOAD:+:${LD_PRELOAD}}
+# ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000"
 
-ARG TMUX_HIST_LIMIT
-RUN {   echo "fpath+=${PURE_PATH}"; \
-        echo "autoload -Uz promptinit; promptinit"; \
-        # Change the `tmux` path color to cyan since
-        # the default blue is unreadable on a dark terminal.
-        echo "zmodload zsh/nearcolor"; \
-        echo "zstyle :prompt:pure:path color cyan"; \
-        echo "prompt pure"; \
-    } >> ${ZDOTDIR}/.zshrc && \
-    # Add autosuggestions from terminal history. May be somewhat distracting.
-    # echo "source ${ZSHA_PATH}/zsh-autosuggestions.zsh" >> ${ZDOTDIR}/.zshrc && \
-    # Add custom `zsh` aliases and settings.
-    {   echo "alias ll='ls -lh'"; \
-        echo "alias wns='watch nvidia-smi'"; \
-        echo "alias hist='history 1'"; \
-    } >> ${ZDOTDIR}/.zshrc && \
-    # Syntax highlighting must be activated at the end of the `.zshrc` file.
-    echo "source ${ZSHS_PATH}/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR}/.zshrc && \
-    # Configure `tmux` to use `zsh` as a non-login shell on startup.
-    {   echo "set -g default-command $(which zsh)"; \
-        echo "set -g history-limit ${TMUX_HIST_LIMIT}"; \
-    } >> /etc/tmux.conf && \
-    # For some reason, `tmux` does not read `/etc/tmux.conf`.
-    echo 'cp /etc/tmux.conf ${HOME}/.tmux.conf' >> ${ZDOTDIR}/.zprofile && \
-    # Change `ZDOTDIR` directory permissions to allow configuration sharing.
-    chmod 755 ${ZDOTDIR} && \
-    # Clear out `/tmp` and restore its default permissions.
-    rm -rf /tmp && mkdir /tmp && chmod 1777 /tmp && \
-    ldconfig  # Update dynamic link cache.
+# ARG TMUX_HIST_LIMIT
+# RUN {   echo "fpath+=${PURE_PATH}"; \
+#         echo "autoload -Uz promptinit; promptinit"; \
+#         # Change the `tmux` path color to cyan since
+#         # the default blue is unreadable on a dark terminal.
+#         echo "zmodload zsh/nearcolor"; \
+#         echo "zstyle :prompt:pure:path color cyan"; \
+#         echo "prompt pure"; \
+#     } >> ${ZDOTDIR}/.zshrc && \
+#     # Add autosuggestions from terminal history. May be somewhat distracting.
+#     # echo "source ${ZSHA_PATH}/zsh-autosuggestions.zsh" >> ${ZDOTDIR}/.zshrc && \
+#     # Add custom `zsh` aliases and settings.
+#     {   echo "alias ll='ls -lh'"; \
+#         echo "alias wns='watch nvidia-smi'"; \
+#         echo "alias hist='history 1'"; \
+#     } >> ${ZDOTDIR}/.zshrc && \
+#     # Syntax highlighting must be activated at the end of the `.zshrc` file.
+#     echo "source ${ZSHS_PATH}/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR}/.zshrc && \
+#     # Configure `tmux` to use `zsh` as a non-login shell on startup.
+#     {   echo "set -g default-command $(which zsh)"; \
+#         echo "set -g history-limit ${TMUX_HIST_LIMIT}"; \
+#     } >> /etc/tmux.conf && \
+#     # For some reason, `tmux` does not read `/etc/tmux.conf`.
+#     echo 'cp /etc/tmux.conf ${HOME}/.tmux.conf' >> ${ZDOTDIR}/.zprofile && \
+#     # Change `ZDOTDIR` directory permissions to allow configuration sharing.
+#     chmod 755 ${ZDOTDIR} && \
+#     # Clear out `/tmp` and restore its default permissions.
+#     rm -rf /tmp && mkdir /tmp && chmod 1777 /tmp && \
+#     ldconfig  # Update dynamic link cache.
 
-ENV PATH=/opt/conda/bin:${PATH}
-# `PROJECT_ROOT` is where the project code will reside.
-ARG PROJECT_ROOT=/opt/project
-ENV PYTHONPATH=${PROJECT_ROOT}${PYTHONPATH:+:${PYTHONPATH}}
-WORKDIR ${PROJECT_ROOT}
-CMD ["/usr/bin/zsh"]
+# ENV PATH=/opt/conda/bin:${PATH}
+# # `PROJECT_ROOT` is where the project code will reside.
+# ARG PROJECT_ROOT=/opt/project
+# ENV PYTHONPATH=${PROJECT_ROOT}${PYTHONPATH:+:${PYTHONPATH}}
+# WORKDIR ${PROJECT_ROOT}
+# CMD ["/usr/bin/zsh"]

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,12 +225,11 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
     echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
-    VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
+    VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
     
-RUN python -m trace -t setup.py install
 ARG VERBOSE=1
 ARG MAX_JOBS=1  
-RUN   VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1  python setup.py install
+RUN python setup.py install
 RUN pip list; exit 1
 
 ###### Additional information for custom builds. ######

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -222,7 +222,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 RUN --mount=type=cache,target=/opt/ccache \
-    python setup.py bdist_wheel -d /tmp/dist 
+    MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -221,7 +221,9 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
+
 RUN --mount=type=cache,target=/opt/ccache \
+    cat setup.py && \
     MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-    USE_SYSTEM_NCCL=0 CMAKE_FRESH=1 MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
+    USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py -v -v bdist_wheel --verbose -d /tmp/dist
+   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py -v -v bdist_wheel --verbose -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -268,6 +268,7 @@ ARG PILLOW_SIMD_VERSION
 #    python -m pip wheel --no-deps --wheel-dir /tmp/dist \
 #        Pillow-SIMD${PILLOW_SIMD_VERSION}
 
+## Use Pillow-SIMD if available and not on aarch64
 ARG USE_PILLOW_SIMD=false
 RUN if [ "$USE_PILLOW_SIMD" = "false" ] || [ "$(uname -m)" = "aarch64" ]; then \
         PILLOW_PACKAGE="Pillow"; \
@@ -429,8 +430,8 @@ RUN $conda clean -fya && find /opt/conda -type d -name '__pycache__' | xargs rm 
 
 # Enable Intel MKL optimizations on AMD CPUs.
 # https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
-RUN echo 'int mkl_serv_intel_cpu_true() {return 1;}' > /opt/conda/fakeintel.c && \
-    gcc -shared -fPIC -o /opt/conda/libfakeintel.so /opt/conda/fakeintel.c
+# RUN echo 'int mkl_serv_intel_cpu_true() {return 1;}' > /opt/conda/fakeintel.c && \
+#     gcc -shared -fPIC -o /opt/conda/libfakeintel.so /opt/conda/fakeintel.c
 
 ########################################################################
 FROM ${TRAIN_IMAGE} AS train-base

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -221,11 +221,13 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
-# RUN pip list; exit 1
+RUN python -c "import platform"
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
    CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist; exit 1
+
+
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,7 +225,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py -v -v bdist_wheel --verbose -d /tmp/dist
+   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python setup.py bdist_wheel -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -228,7 +228,7 @@ RUN --mount=type=cache,target=/opt/ccache \
     VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
     
 RUN python -m trace -t setup.py install
-RUN python  VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1  setup.py install
+RUN   VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1  python setup.py install
 RUN pip list; exit 1
 
 ###### Additional information for custom builds. ######

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -222,8 +222,9 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 RUN --mount=type=cache,target=/opt/ccache \
-    python setup.py bdist_wheel -d /tmp/dist && \
-    python setup.py install
+    python setup.py bdist_wheel -d /tmp/dist 
+    
+RUN python setup.py install
 
 ###### Additional information for custom builds. ######
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-    echo $TORCH_CUDA_ARCH_LIST && \
+    echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
     USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,7 +225,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
     echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
-    VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py --build bdist_wheel -d /tmp/dist 
+    VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
     
 RUN python  -m trace -t setup.py install
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,7 +225,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist
+   CMAKE_FRESH=1 MAX_JOBS=1 USE_SYSTEM_NCCL=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist; exit 1
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -227,7 +227,7 @@ RUN --mount=type=cache,target=/opt/ccache \
     echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
     VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py bdist_wheel -d /tmp/dist 
     
-RUN python  -m trace -t setup.py install
+RUN python -m trace -t setup.py install
 
 ###### Additional information for custom builds. ######
 
@@ -300,11 +300,13 @@ FROM build-torch AS build-vision
 WORKDIR /opt/vision
 COPY --link --from=clone-vision /opt/vision /opt/vision
 
+RUN pip list; exit 1
+
 # Install Pillow-SIMD before TorchVision build and add it to `/tmp/dist`.
 # Pillow will be uninstalled if it is present.
 RUN --mount=type=bind,from=build-pillow,source=/tmp/dist,target=/tmp/dist \
-    python -m pip uninstall -y pillow && \
     python -m pip install --no-deps /tmp/dist/*
+# python -m pip uninstall -y pillow && \
 
 ARG USE_CUDA
 ARG USE_PRECOMPILED_HEADERS

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -221,7 +221,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
-RUN python -c "print('X')" && exit 1
+# RUN python -c "print('X')" && exit 1
 
 RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -221,7 +221,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
 # RUN ld -verbose
 ARG USE_PRIORITIZED_TEXT_FOR_LD=0
-RUN python -c "import platform; print( platform.machine())" && exit 1
+RUN python -c "import platform; print('X'); print( platform.machine()); print('y')" && exit 1
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -220,7 +220,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # " we strongly recommend enabling linker script optimization for ARM + CUDA"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
 # RUN ld -verbose
-ARG USE_PRIORITIZED_TEXT_FOR_LD=1
+ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 RUN --mount=type=cache,target=/opt/ccache \
     python setup.py bdist_wheel -d /tmp/dist && \
     python setup.py install

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -219,7 +219,7 @@ ARG TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 # Install PyTorch for subsidiary libraries (e.g., TorchVision).
 # " we strongly recommend enabling linker script optimization for ARM + CUDA"
 # To do so please export USE_PRIORITIZED_TEXT_FOR_LD=1
-ARG USE_PRIORITIZED_TEXT_FOR_LD 
+ARG USE_PRIORITIZED_TEXT_FOR_LD=1
 RUN --mount=type=cache,target=/opt/ccache \
     python setup.py bdist_wheel -d /tmp/dist && \
     python setup.py install

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   python setup.py bdist_wheel -v -d /tmp/dist
+   python setup.py bdist_wheel --verbose -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -225,7 +225,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
     echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
-    USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
+    USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python --trace setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install
 

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,7 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
-   python setup.py bdist_wheel -d /tmp/dist && exit 1
+   python setup.py bdist_wheel -d /tmp/dist
     
 ARG VERBOSE=1
 ARG MAX_JOBS=1  

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -224,6 +224,7 @@ ARG USE_PRIORITIZED_TEXT_FOR_LD=0
 
 # cat setup.py && \
 RUN --mount=type=cache,target=/opt/ccache \
+    echo $TORCH_CUDA_ARCH_LIST && \
     USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python setup.py bdist_wheel -d /tmp/dist 
     
 RUN python setup.py install

--- a/dockerfiles/train.Dockerfile
+++ b/dockerfiles/train.Dockerfile
@@ -227,7 +227,7 @@ RUN --mount=type=cache,target=/opt/ccache \
     echo "ARCHLIST: $TORCH_CUDA_ARCH_LIST" && \
     VERBOSE_SCRIPT=1 USE_SYSTEM_NCCL=1 CMAKE_FRESH=1 MAX_JOBS=1 python -m trace -t setup.py --build bdist_wheel -d /tmp/dist 
     
-RUN python setup.py install
+RUN python  -m trace -t setup.py install
 
 ###### Additional information for custom builds. ######
 

--- a/reqs/train-conda-build.requirements.txt
+++ b/reqs/train-conda-build.requirements.txt
@@ -23,7 +23,7 @@ numpy
 psutil
 pyyaml
 requests
-setuptools
+setuptools===59.5.0
 sympy
 types-dataclasses
 typing-extensions

--- a/reqs/train-conda-build.requirements.txt
+++ b/reqs/train-conda-build.requirements.txt
@@ -23,7 +23,7 @@ numpy
 psutil
 pyyaml
 requests
-setuptools==59.5.0
+setuptools#==59.5.0
 sympy
 types-dataclasses
 typing-extensions

--- a/reqs/train-conda-build.requirements.txt
+++ b/reqs/train-conda-build.requirements.txt
@@ -23,7 +23,7 @@ numpy
 psutil
 pyyaml
 requests
-setuptools===59.5.0
+setuptools==59.5.0
 sympy
 types-dataclasses
 typing-extensions

--- a/test-torch-vision-nms.py
+++ b/test-torch-vision-nms.py
@@ -1,0 +1,44 @@
+import torch
+
+
+def check_environment() -> None:
+   """Check the environment for potential issues"""
+   print('Environment Check:')
+   print(f'PyTorch CUDA available: {torch.cuda.is_available()}')
+
+
+   if torch.cuda.is_available():
+       print(f'PyTorch CUDA version: {torch.version.cuda}')
+       print(f'Detected CUDA devices: {torch.cuda.device_count()}')
+
+
+       # Try a simple CUDA operation
+       try:
+           x = torch.randn(2, 2).cuda()
+           y = torch.randn(2, 2).cuda()
+           z = torch.mm(x, y)
+           print('Basic CUDA operations work')
+       except Exception as e:
+           print(f'Basic CUDA operations failed: {e}')
+
+
+   # Check if torchvision ops work
+   try:
+       from torchvision.ops import nms
+
+
+       boxes = torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1]], dtype=torch.float32)
+       scores = torch.tensor([0.9, 0.8], dtype=torch.float32)
+
+
+       if torch.cuda.is_available():
+           boxes = boxes.cuda()
+           scores = scores.cuda()
+
+
+       keep = nms(boxes, scores, 0.5)
+       print('torchvision.ops.nms works on current device')	
+   except Exception as e:
+       print(f'torchvision.ops.nms failed: {e}')
+if __name__ == '__main__':
+   check_environment()


### PR DESCRIPTION
Build Pytorch for Jetson Thor

We have the following version requirements
Python 3.11.13
NVIDIA-SMI 580.00                 
Driver Version: 580.00        
CUDA Version: 13.0 
Sm_110
aarch64

```
"""
MVP script to reproduce CUDA NMS error with TorchScript
RuntimeError: CUDA error: no kernel image is available for execution on the device
"""
import torch




def check_environment() -> None:
   """Check the environment for potential issues"""
   print('Environment Check:')
   print(f'PyTorch CUDA available: {torch.cuda.is_available()}')


   if torch.cuda.is_available():
       print(f'PyTorch CUDA version: {torch.version.cuda}')
       print(f'Detected CUDA devices: {torch.cuda.device_count()}')


       # Try a simple CUDA operation
       try:
           x = torch.randn(2, 2).cuda()
           y = torch.randn(2, 2).cuda()
           z = torch.mm(x, y)
           print('Basic CUDA operations work')
       except Exception as e:
           print(f'Basic CUDA operations failed: {e}')


   # Check if torchvision ops work
   try:
       from torchvision.ops import nms


       boxes = torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1]], dtype=torch.float32)
       scores = torch.tensor([0.9, 0.8], dtype=torch.float32)


       if torch.cuda.is_available():
           boxes = boxes.cuda()
           scores = scores.cuda()


       keep = nms(boxes, scores, 0.5)
       print('torchvision.ops.nms works on current device')	
   except Exception as e:
       print(f'torchvision.ops.nms failed: {e}')




if __name__ == '__main__':
   print('CUDA NMS Error Reproduction Script')
   print('=' * 50)


   # Check environment first
   check_environment()
```

```
torchvision.ops.nms failed: CUDA error: no kernel image is available for execution on the device
Search for `cudaErrorNoKernelImageForDevice' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```


```
# When using the `root` user with `UID=0`/`USR=root`, set `ADD_USER=exclude`.
GID=1000
UID=1000
GRP=pickle
USR=pickle
HOST_ROOT=.
SERVICE=train
# Do not use the same `PROJECT` name for different projects on the same host!
PROJECT=train-pickle-20250918-161617
PROJECT_ROOT=/opt/project
IMAGE_NAME=cresset:train-pickle-20250918-161617
COMMAND=/usr/bin/zsh --login
TZ=Asia/Seoul

PYTORCH_VERSION_TAG=v2.8.0
TORCHVISION_VERSION_TAG=v0.23.0
PYTORCH_INDEX_URL='build not download'
CCC=11.0
PYTHON_VERSION=3.11.13
IMAGE_FLAVOR=devel
CUDA_VERSION=13.0.1
BUILD_MODE=include
LINUX_DISTRO=ubuntu   # Visit the NVIDIA Docker Hub repo for available base images.
DISTRO_VERSION=22.04  # https://hub.docker.com/r/nvidia/cuda/tags
TARGET_STAGE=train
#CONDA_URL=https://github.com/mamba-org/micromamba-releases/releases/download/2.3.2-0/micromamba-linux-aarch64
#CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh
CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_25.7.0-2-Linux-aarch64.sh
CONDA_MANAGER=conda
MKL_MODE=exclude # The Intel(R) Math Kernel Library (MKL)
```